### PR TITLE
Fix soft delete

### DIFF
--- a/CTCommons/MSTranscription/MSTWord.cs
+++ b/CTCommons/MSTranscription/MSTWord.cs
@@ -163,10 +163,11 @@ namespace CTCommons.MSTranscription
             return sb.ToString();
         }
 
-        public static void AppendCaptions(List<Caption> captions, List<MSTWord> words)
+        public static List<Caption> AppendCaptions(int captionsCount, List<MSTWord> words)
         {
+            List<Caption> captions = new List<Caption>();
             int captionLength = Globals.CAPTION_LENGTH;
-            int currCounter = captions.Count + 1;
+            int currCounter = captionsCount + 1;
             int currLength = 0;
             StringBuilder currSentence = new StringBuilder();
             TimeSpan? startTime = null;
@@ -203,6 +204,8 @@ namespace CTCommons.MSTranscription
                     Text = currSentence.ToString().Trim()
                 });
             }
+
+            return captions;
         }
     }
 }

--- a/ClassTranscribeDatabase/CTDbContext.cs
+++ b/ClassTranscribeDatabase/CTDbContext.cs
@@ -168,7 +168,7 @@ namespace ClassTranscribeDatabase
 
             // Configure m-to-n relationships.
             builder.Entity<CourseOffering>()
-            .HasKey(t => new { t.CourseId, t.OfferingId });
+            .HasIndex(t => new { t.CourseId, t.OfferingId, t.DeletedAt }).IsUnique();
 
             builder.Entity<CourseOffering>()
                 .HasOne(pt => pt.Course)
@@ -181,7 +181,7 @@ namespace ClassTranscribeDatabase
                 .HasForeignKey(pt => pt.OfferingId);
 
             builder.Entity<UserOffering>()
-            .HasKey(t => new { t.ApplicationUserId, t.OfferingId });
+            .HasIndex(t => new { t.ApplicationUserId, t.OfferingId, t.IdentityRoleId, t.DeletedAt }).IsUnique();
 
             builder.Entity<UserOffering>()
                 .HasOne(pt => pt.Offering)
@@ -212,8 +212,8 @@ namespace ClassTranscribeDatabase
             builder.Entity<TaskItem>().Property(m => m.TaskParameters).HasJsonValueConversion();
             builder.Entity<TaskItem>().Property(m => m.ResultData).HasJsonValueConversion();
 
-            builder.Entity<Subscription>().HasAlternateKey(s => new { s.ResourceType, s.ResourceId, s.ApplicationUserId });
-            builder.Entity<TaskItem>().HasAlternateKey(t => new { t.UniqueId, t.TaskType });
+            builder.Entity<Subscription>().HasIndex(s => new { s.ResourceType, s.ResourceId, s.ApplicationUserId, s.DeletedAt }).IsUnique();
+            builder.Entity<TaskItem>().HasIndex(t => new { t.UniqueId, t.TaskType, t.DeletedAt }).IsUnique();
         }
         public override int SaveChanges(bool acceptAllChangesOnSuccess)
         {
@@ -253,6 +253,7 @@ namespace ClassTranscribeDatabase
                         case EntityState.Deleted:
                             entry.State = EntityState.Modified;
                             entity.IsDeletedStatus = Status.Deleted;
+                            entity.DeletedAt = now;
                             break;
                     }
                 }

--- a/ClassTranscribeDatabase/CaptionQueries.cs
+++ b/ClassTranscribeDatabase/CaptionQueries.cs
@@ -23,8 +23,15 @@ namespace ClassTranscribeDatabase
         /// <param name="language">Language of the captions to fetch.</param>
         public async Task<List<Caption>> GetCaptionsAsync(string videoId, string language = "en-US")
         {
-            var transcriptionId = _context.Transcriptions.Where(t => t.Language == language && t.VideoId == videoId).First().Id;
-            return await GetCaptionsAsync(transcriptionId);
+            try
+            {
+                var transcriptionId = _context.Transcriptions.Where(t => t.Language == language && t.VideoId == videoId).First().Id;
+                return await GetCaptionsAsync(transcriptionId);
+            }
+            catch (System.InvalidOperationException e)
+            {
+                return new List<Caption>();
+            }
         }
 
         /// <summary>

--- a/ClassTranscribeDatabase/Migrations/20200804171606_Soft_Delete_Fix.Designer.cs
+++ b/ClassTranscribeDatabase/Migrations/20200804171606_Soft_Delete_Fix.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using ClassTranscribeDatabase;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace ClassTranscribeDatabase.Migrations
 {
     [DbContext(typeof(CTDbContext))]
-    partial class CTDbContextModelSnapshot : ModelSnapshot
+    [Migration("20200804171606_Soft_Delete_Fix")]
+    partial class Soft_Delete_Fix
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/ClassTranscribeDatabase/Migrations/20200804171606_Soft_Delete_Fix.cs
+++ b/ClassTranscribeDatabase/Migrations/20200804171606_Soft_Delete_Fix.cs
@@ -1,0 +1,741 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace ClassTranscribeDatabase.Migrations
+{
+    public partial class Soft_Delete_Fix : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_CourseOfferings_Courses_CourseId",
+                table: "CourseOfferings");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_CourseOfferings_Offerings_OfferingId",
+                table: "CourseOfferings");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Subscriptions_AspNetUsers_ApplicationUserId",
+                table: "Subscriptions");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_UserOfferings_AspNetUsers_ApplicationUserId",
+                table: "UserOfferings");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_UserOfferings_Offerings_OfferingId",
+                table: "UserOfferings");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_UserOfferings",
+                table: "UserOfferings");
+
+            migrationBuilder.DropUniqueConstraint(
+                name: "AK_TaskItems_UniqueId_TaskType",
+                table: "TaskItems");
+
+            migrationBuilder.DropUniqueConstraint(
+                name: "AK_Subscriptions_ResourceType_ResourceId_ApplicationUserId",
+                table: "Subscriptions");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_CourseOfferings",
+                table: "CourseOfferings");
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "DeletedAt",
+                table: "WatchHistories",
+                nullable: false,
+                defaultValue: new DateTime(1900, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc));
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "DeletedAt",
+                table: "Videos",
+                nullable: false,
+                defaultValue: new DateTime(1900, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc));
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Id",
+                table: "UserOfferings",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "text",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "OfferingId",
+                table: "UserOfferings",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "text");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "ApplicationUserId",
+                table: "UserOfferings",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "text");
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "DeletedAt",
+                table: "UserOfferings",
+                nullable: false,
+                defaultValue: new DateTime(1900, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc));
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "DeletedAt",
+                table: "Universities",
+                nullable: false,
+                defaultValue: new DateTime(1900, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc));
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "DeletedAt",
+                table: "Transcriptions",
+                nullable: false,
+                defaultValue: new DateTime(1900, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc));
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "DeletedAt",
+                table: "Terms",
+                nullable: false,
+                defaultValue: new DateTime(1900, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc));
+
+            migrationBuilder.AlterColumn<string>(
+                name: "UniqueId",
+                table: "TaskItems",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "text");
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "DeletedAt",
+                table: "TaskItems",
+                nullable: false,
+                defaultValue: new DateTime(1900, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc));
+
+            migrationBuilder.AlterColumn<string>(
+                name: "ResourceId",
+                table: "Subscriptions",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "text");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "ApplicationUserId",
+                table: "Subscriptions",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "text");
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "DeletedAt",
+                table: "Subscriptions",
+                nullable: false,
+                defaultValue: new DateTime(1900, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc));
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "DeletedAt",
+                table: "Playlists",
+                nullable: false,
+                defaultValue: new DateTime(1900, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc));
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "DeletedAt",
+                table: "Offerings",
+                nullable: false,
+                defaultValue: new DateTime(1900, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc));
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "DeletedAt",
+                table: "Messages",
+                nullable: false,
+                defaultValue: new DateTime(1900, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc));
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "DeletedAt",
+                table: "Medias",
+                nullable: false,
+                defaultValue: new DateTime(1900, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc));
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "DeletedAt",
+                table: "Logs",
+                nullable: false,
+                defaultValue: new DateTime(1900, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc));
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "DeletedAt",
+                table: "FileRecords",
+                nullable: false,
+                defaultValue: new DateTime(1900, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc));
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "DeletedAt",
+                table: "EPubs",
+                nullable: false,
+                defaultValue: new DateTime(1900, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc));
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "DeletedAt",
+                table: "EPubChapters",
+                nullable: false,
+                defaultValue: new DateTime(1900, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc));
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "DeletedAt",
+                table: "Dictionaries",
+                nullable: false,
+                defaultValue: new DateTime(1900, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc));
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "DeletedAt",
+                table: "Departments",
+                nullable: false,
+                defaultValue: new DateTime(1900, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc));
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "DeletedAt",
+                table: "Courses",
+                nullable: false,
+                defaultValue: new DateTime(1900, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc));
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Id",
+                table: "CourseOfferings",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "text",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "OfferingId",
+                table: "CourseOfferings",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "text");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "CourseId",
+                table: "CourseOfferings",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "text");
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "DeletedAt",
+                table: "CourseOfferings",
+                nullable: false,
+                defaultValue: new DateTime(1900, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc));
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "DeletedAt",
+                table: "Captions",
+                nullable: false,
+                defaultValue: new DateTime(1900, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                table: "WatchHistories",
+                keyColumn: "IsDeletedStatus",
+                keyValue: 1,
+                column: "DeletedAt",
+                value: new DateTime(1900, 2, 1, 0, 0, 0, 0, DateTimeKind.Utc)
+                );
+
+            migrationBuilder.UpdateData(
+                table: "Videos",
+                keyColumn: "IsDeletedStatus",
+                keyValue: 1,
+                column: "DeletedAt",
+                value: new DateTime(1900, 2, 1, 0, 0, 0, 0, DateTimeKind.Utc)
+                );
+
+            migrationBuilder.UpdateData(
+                table: "UserOfferings",
+                keyColumn: "IsDeletedStatus",
+                keyValue: 1,
+                column: "DeletedAt",
+                value: new DateTime(1900, 2, 1, 0, 0, 0, 0, DateTimeKind.Utc)
+                );
+
+            migrationBuilder.UpdateData(
+                table: "Universities",
+                keyColumn: "IsDeletedStatus",
+                keyValue: 1,
+                column: "DeletedAt",
+                value: new DateTime(1900, 2, 1, 0, 0, 0, 0, DateTimeKind.Utc)
+                );
+
+            migrationBuilder.UpdateData(
+                table: "Transcriptions",
+                keyColumn: "IsDeletedStatus",
+                keyValue: 1,
+                column: "DeletedAt",
+                value: new DateTime(1900, 2, 1, 0, 0, 0, 0, DateTimeKind.Utc)
+                );
+
+            migrationBuilder.UpdateData(
+                table: "Terms",
+                keyColumn: "IsDeletedStatus",
+                keyValue: 1,
+                column: "DeletedAt",
+                value: new DateTime(1900, 2, 1, 0, 0, 0, 0, DateTimeKind.Utc)
+                );
+
+            migrationBuilder.UpdateData(
+                table: "TaskItems",
+                keyColumn: "IsDeletedStatus",
+                keyValue: 1,
+                column: "DeletedAt",
+                value: new DateTime(1900, 2, 1, 0, 0, 0, 0, DateTimeKind.Utc)
+                );
+
+            migrationBuilder.UpdateData(
+                table: "Subscriptions",
+                keyColumn: "IsDeletedStatus",
+                keyValue: 1,
+                column: "DeletedAt",
+                value: new DateTime(1900, 2, 1, 0, 0, 0, 0, DateTimeKind.Utc)
+                );
+
+            migrationBuilder.UpdateData(
+                table: "Playlists",
+                keyColumn: "IsDeletedStatus",
+                keyValue: 1,
+                column: "DeletedAt",
+                value: new DateTime(1900, 2, 1, 0, 0, 0, 0, DateTimeKind.Utc)
+                );
+
+            migrationBuilder.UpdateData(
+                table: "Offerings",
+                keyColumn: "IsDeletedStatus",
+                keyValue: 1,
+                column: "DeletedAt",
+                value: new DateTime(1900, 2, 1, 0, 0, 0, 0, DateTimeKind.Utc)
+                );
+
+            migrationBuilder.UpdateData(
+                table: "Messages",
+                keyColumn: "IsDeletedStatus",
+                keyValue: 1,
+                column: "DeletedAt",
+                value: new DateTime(1900, 2, 1, 0, 0, 0, 0, DateTimeKind.Utc)
+                );
+
+            migrationBuilder.UpdateData(
+                table: "Medias",
+                keyColumn: "IsDeletedStatus",
+                keyValue: 1,
+                column: "DeletedAt",
+                value: new DateTime(1900, 2, 1, 0, 0, 0, 0, DateTimeKind.Utc)
+                );
+
+            migrationBuilder.UpdateData(
+                table: "Logs",
+                keyColumn: "IsDeletedStatus",
+                keyValue: 1,
+                column: "DeletedAt",
+                value: new DateTime(1900, 2, 1, 0, 0, 0, 0, DateTimeKind.Utc)
+                );
+
+            migrationBuilder.UpdateData(
+                table: "FileRecords",
+                keyColumn: "IsDeletedStatus",
+                keyValue: 1,
+                column: "DeletedAt",
+                value: new DateTime(1900, 2, 1, 0, 0, 0, 0, DateTimeKind.Utc)
+                );
+
+            migrationBuilder.UpdateData(
+                table: "EPubs",
+                keyColumn: "IsDeletedStatus",
+                keyValue: 1,
+                column: "DeletedAt",
+                value: new DateTime(1900, 2, 1, 0, 0, 0, 0, DateTimeKind.Utc)
+                );
+
+            migrationBuilder.UpdateData(
+                table: "EPubChapters",
+                keyColumn: "IsDeletedStatus",
+                keyValue: 1,
+                column: "DeletedAt",
+                value: new DateTime(1900, 2, 1, 0, 0, 0, 0, DateTimeKind.Utc)
+                );
+
+            migrationBuilder.UpdateData(
+                table: "Dictionaries",
+                keyColumn: "IsDeletedStatus",
+                keyValue: 1,
+                column: "DeletedAt",
+                value: new DateTime(1900, 2, 1, 0, 0, 0, 0, DateTimeKind.Utc)
+                );
+
+            migrationBuilder.UpdateData(
+                table: "Departments",
+                keyColumn: "IsDeletedStatus",
+                keyValue: 1,
+                column: "DeletedAt",
+                value: new DateTime(1900, 2, 1, 0, 0, 0, 0, DateTimeKind.Utc)
+                );
+
+            migrationBuilder.UpdateData(
+                table: "Courses",
+                keyColumn: "IsDeletedStatus",
+                keyValue: 1,
+                column: "DeletedAt",
+                value: new DateTime(1900, 2, 1, 0, 0, 0, 0, DateTimeKind.Utc)
+                );
+
+            migrationBuilder.UpdateData(
+                table: "CourseOfferings",
+                keyColumn: "IsDeletedStatus",
+                keyValue: 1,
+                column: "DeletedAt",
+                value: new DateTime(1900, 2, 1, 0, 0, 0, 0, DateTimeKind.Utc)
+                );
+
+            migrationBuilder.UpdateData(
+                table: "Captions",
+                keyColumn: "IsDeletedStatus",
+                keyValue: 1,
+                column: "DeletedAt",
+                value: new DateTime(1900, 2, 1, 0, 0, 0, 0, DateTimeKind.Utc)
+                );
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_UserOfferings",
+                table: "UserOfferings",
+                column: "Id");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_CourseOfferings",
+                table: "CourseOfferings",
+                column: "Id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserOfferings_ApplicationUserId_OfferingId_IdentityRoleId_D~",
+                table: "UserOfferings",
+                columns: new[] { "ApplicationUserId", "OfferingId", "IdentityRoleId", "DeletedAt" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TaskItems_UniqueId_TaskType_DeletedAt",
+                table: "TaskItems",
+                columns: new[] { "UniqueId", "TaskType", "DeletedAt" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Subscriptions_ResourceType_ResourceId_ApplicationUserId_Del~",
+                table: "Subscriptions",
+                columns: new[] { "ResourceType", "ResourceId", "ApplicationUserId", "DeletedAt" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CourseOfferings_CourseId_OfferingId_DeletedAt",
+                table: "CourseOfferings",
+                columns: new[] { "CourseId", "OfferingId", "DeletedAt" },
+                unique: true);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_CourseOfferings_Courses_CourseId",
+                table: "CourseOfferings",
+                column: "CourseId",
+                principalTable: "Courses",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_CourseOfferings_Offerings_OfferingId",
+                table: "CourseOfferings",
+                column: "OfferingId",
+                principalTable: "Offerings",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Subscriptions_AspNetUsers_ApplicationUserId",
+                table: "Subscriptions",
+                column: "ApplicationUserId",
+                principalTable: "AspNetUsers",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_UserOfferings_AspNetUsers_ApplicationUserId",
+                table: "UserOfferings",
+                column: "ApplicationUserId",
+                principalTable: "AspNetUsers",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_UserOfferings_Offerings_OfferingId",
+                table: "UserOfferings",
+                column: "OfferingId",
+                principalTable: "Offerings",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_CourseOfferings_Courses_CourseId",
+                table: "CourseOfferings");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_CourseOfferings_Offerings_OfferingId",
+                table: "CourseOfferings");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Subscriptions_AspNetUsers_ApplicationUserId",
+                table: "Subscriptions");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_UserOfferings_AspNetUsers_ApplicationUserId",
+                table: "UserOfferings");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_UserOfferings_Offerings_OfferingId",
+                table: "UserOfferings");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_UserOfferings",
+                table: "UserOfferings");
+
+            migrationBuilder.DropIndex(
+                name: "IX_UserOfferings_ApplicationUserId_OfferingId_IdentityRoleId_D~",
+                table: "UserOfferings");
+
+            migrationBuilder.DropIndex(
+                name: "IX_TaskItems_UniqueId_TaskType_DeletedAt",
+                table: "TaskItems");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Subscriptions_ResourceType_ResourceId_ApplicationUserId_Del~",
+                table: "Subscriptions");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_CourseOfferings",
+                table: "CourseOfferings");
+
+            migrationBuilder.DropIndex(
+                name: "IX_CourseOfferings_CourseId_OfferingId_DeletedAt",
+                table: "CourseOfferings");
+
+            migrationBuilder.DropColumn(
+                name: "DeletedAt",
+                table: "WatchHistories");
+
+            migrationBuilder.DropColumn(
+                name: "DeletedAt",
+                table: "Videos");
+
+            migrationBuilder.DropColumn(
+                name: "DeletedAt",
+                table: "UserOfferings");
+
+            migrationBuilder.DropColumn(
+                name: "DeletedAt",
+                table: "Universities");
+
+            migrationBuilder.DropColumn(
+                name: "DeletedAt",
+                table: "Transcriptions");
+
+            migrationBuilder.DropColumn(
+                name: "DeletedAt",
+                table: "Terms");
+
+            migrationBuilder.DropColumn(
+                name: "DeletedAt",
+                table: "TaskItems");
+
+            migrationBuilder.DropColumn(
+                name: "DeletedAt",
+                table: "Subscriptions");
+
+            migrationBuilder.DropColumn(
+                name: "DeletedAt",
+                table: "Playlists");
+
+            migrationBuilder.DropColumn(
+                name: "DeletedAt",
+                table: "Offerings");
+
+            migrationBuilder.DropColumn(
+                name: "DeletedAt",
+                table: "Messages");
+
+            migrationBuilder.DropColumn(
+                name: "DeletedAt",
+                table: "Medias");
+
+            migrationBuilder.DropColumn(
+                name: "DeletedAt",
+                table: "Logs");
+
+            migrationBuilder.DropColumn(
+                name: "DeletedAt",
+                table: "FileRecords");
+
+            migrationBuilder.DropColumn(
+                name: "DeletedAt",
+                table: "EPubs");
+
+            migrationBuilder.DropColumn(
+                name: "DeletedAt",
+                table: "EPubChapters");
+
+            migrationBuilder.DropColumn(
+                name: "DeletedAt",
+                table: "Dictionaries");
+
+            migrationBuilder.DropColumn(
+                name: "DeletedAt",
+                table: "Departments");
+
+            migrationBuilder.DropColumn(
+                name: "DeletedAt",
+                table: "Courses");
+
+            migrationBuilder.DropColumn(
+                name: "DeletedAt",
+                table: "CourseOfferings");
+
+            migrationBuilder.DropColumn(
+                name: "DeletedAt",
+                table: "Captions");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "OfferingId",
+                table: "UserOfferings",
+                type: "text",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "ApplicationUserId",
+                table: "UserOfferings",
+                type: "text",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Id",
+                table: "UserOfferings",
+                type: "text",
+                nullable: true,
+                oldClrType: typeof(string));
+
+            migrationBuilder.AlterColumn<string>(
+                name: "UniqueId",
+                table: "TaskItems",
+                type: "text",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "ResourceId",
+                table: "Subscriptions",
+                type: "text",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "ApplicationUserId",
+                table: "Subscriptions",
+                type: "text",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "OfferingId",
+                table: "CourseOfferings",
+                type: "text",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "CourseId",
+                table: "CourseOfferings",
+                type: "text",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Id",
+                table: "CourseOfferings",
+                type: "text",
+                nullable: true,
+                oldClrType: typeof(string));
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_UserOfferings",
+                table: "UserOfferings",
+                columns: new[] { "ApplicationUserId", "OfferingId" });
+
+            migrationBuilder.AddUniqueConstraint(
+                name: "AK_TaskItems_UniqueId_TaskType",
+                table: "TaskItems",
+                columns: new[] { "UniqueId", "TaskType" });
+
+            migrationBuilder.AddUniqueConstraint(
+                name: "AK_Subscriptions_ResourceType_ResourceId_ApplicationUserId",
+                table: "Subscriptions",
+                columns: new[] { "ResourceType", "ResourceId", "ApplicationUserId" });
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_CourseOfferings",
+                table: "CourseOfferings",
+                columns: new[] { "CourseId", "OfferingId" });
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_CourseOfferings_Courses_CourseId",
+                table: "CourseOfferings",
+                column: "CourseId",
+                principalTable: "Courses",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_CourseOfferings_Offerings_OfferingId",
+                table: "CourseOfferings",
+                column: "OfferingId",
+                principalTable: "Offerings",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Subscriptions_AspNetUsers_ApplicationUserId",
+                table: "Subscriptions",
+                column: "ApplicationUserId",
+                principalTable: "AspNetUsers",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_UserOfferings_AspNetUsers_ApplicationUserId",
+                table: "UserOfferings",
+                column: "ApplicationUserId",
+                principalTable: "AspNetUsers",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_UserOfferings_Offerings_OfferingId",
+                table: "UserOfferings",
+                column: "OfferingId",
+                principalTable: "Offerings",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+    }
+}

--- a/ClassTranscribeDatabase/Models/Caption.cs
+++ b/ClassTranscribeDatabase/Models/Caption.cs
@@ -60,10 +60,11 @@ namespace ClassTranscribeDatabase.Models
         /// <param name="Begin">The beginning time stamp of the recognizedSpeech</param>
         /// <param name="End">The end time stamp of the recognizedSpeech</param>
         /// <param name="recognizedSpeech">Recognized Speech received from the Speech Services API.</param>
-        public static void AppendCaptions(List<Caption> captions, TimeSpan Begin, TimeSpan End, string recognizedSpeech)
+        public static List<Caption> AppendCaptions(int captionsCount, TimeSpan Begin, TimeSpan End, string recognizedSpeech)
         {
+            List<Caption> captions = new List<Caption>();
             int captionLength = Globals.CAPTION_LENGTH;
-            int currCounter = captions.Count + 1;
+            int currCounter = captionsCount + 1;
             string tempCaption = recognizedSpeech;
             string caption;
             int newDuration;
@@ -111,6 +112,7 @@ namespace ClassTranscribeDatabase.Models
                 curBegin = curEnd;
                 curDuration = End.Subtract(curBegin);
             }
+            return captions;
         }
 
         /// <summary>
@@ -143,6 +145,54 @@ namespace ClassTranscribeDatabase.Models
             }
             WriteTextToFile(Subtitle, vttFile);
             return vttFile;
+        }
+
+        /// <summary>
+        /// Parse a WebVTT file into a list of captions.
+        /// </summary>
+        /// <returns>A list of the caption representing the vtt file or null if unsuccessful</returns>
+        public static List<Caption> WebVTTFileToCaption(string file)
+        {
+            List<Caption> captions = new List<Caption>();
+            string text = File.ReadAllText(file);
+            string[] cues = text.Split("\n\n");
+            int idx = 0;
+
+            for (int i = 0; i < cues.Length; i++)
+            {
+                var cue = cues[i];
+                if (i == 0 && cue.Substring(0, 6) != "WEBVTT") return null;
+
+                if (cue.Contains("-->"))
+                {
+                    string[] lines = cue.Split("\n");
+                    Caption caption = new Caption
+                    {
+                        Text = "",
+                        Index = idx
+                    };
+                    idx++;
+
+                    for (int j = 0; j < lines.Length; j++)
+                    {
+                        var line = lines[j];
+                        if (line.Contains("-->"))
+                        {
+                            // Try parse vtt timestamp into TimeSpan
+                            string[] timestamps = line.Split("-->");
+                            caption.Begin = TimeSpan.Parse(timestamps[0].Trim());
+                            caption.End = TimeSpan.Parse(timestamps[1].Trim());
+                        }
+                        else
+                        {
+                            // Otherwise is cue payload
+                            caption.Text += line;
+                        }
+                    }
+                    captions.Add(caption);
+                }
+            }
+            return captions;
         }
 
         /// <summary>

--- a/ClassTranscribeDatabase/Models/Models.cs
+++ b/ClassTranscribeDatabase/Models/Models.cs
@@ -85,6 +85,8 @@ namespace ClassTranscribeDatabase.Models
         public string LastUpdatedBy { get; set; }
         [IgnoreDataMember]
         public Status IsDeletedStatus { get; set; }
+        [IgnoreDataMember]
+        public DateTime DeletedAt { get; set; } = new DateTime(1900, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
 
         public ResourceType GetResourceType()
         {

--- a/ClassTranscribeServer/Controllers/AccountController.cs
+++ b/ClassTranscribeServer/Controllers/AccountController.cs
@@ -115,7 +115,7 @@ namespace ClassTranscribeServer.Controllers
             {
                 if (Globals.appSettings.TEST_SIGN_IN == "true")
                 {
-                    ApplicationUser user = await _userManager.FindByEmailAsync("testuser999@illinois.edu");
+                    ApplicationUser user = await _userManager.FindByEmailAsync("testuser999@classtranscribe.com");
                     await _signInManager.SignInAsync(user, false);
                     loggedInDTO = await GenerateJwtToken(user);
                 }

--- a/DevExperiments/TempCode.cs
+++ b/DevExperiments/TempCode.cs
@@ -23,7 +23,7 @@ namespace CTCommons
         private readonly CTDbContext context;
         private readonly MSTranscriptionService _transcriptionService;
         private readonly RpcClient _rpcClient;
-        
+
         public TempCode(CTDbContext c, MSTranscriptionService transcriptionService, RpcClient rpcClient)
         {
             context = c;
@@ -43,8 +43,26 @@ namespace CTCommons
             // Add any temporary code.
 
             Console.WriteLine("Hi");
+            
+            
+            Console.WriteLine("H2");
 
-            Console.WriteLine("Hi");
+        }
+        // Example code (never called)
+        private async Task TestDirectYouTubeChannel()
+        {
+            JObject json = new JObject();
+            json.Add("isChannel", "1");
+            var x = _rpcClient.PythonServerClient.GetYoutubePlaylistRPC(new CTGrpc.PlaylistRequest
+            {
+                Identifier = "UCi8e0iOVk1fEOogdfu4YgfA",
+                Metadata = new CTGrpc.JsonString() { Json = json.ToString() },
+
+
+            });
+            JArray jArray = JArray.Parse(x.Json);
+
+            Console.WriteLine(x.Json);
         }
     }
 }

--- a/DevExperiments/TempCode.cs
+++ b/DevExperiments/TempCode.cs
@@ -55,7 +55,7 @@ namespace CTCommons
             json.Add("isChannel", "1");
             var x = _rpcClient.PythonServerClient.GetYoutubePlaylistRPC(new CTGrpc.PlaylistRequest
             {
-                Identifier = "UCi8e0iOVk1fEOogdfu4YgfA",
+                Url = "UCi8e0iOVk1fEOogdfu4YgfA",
                 Metadata = new CTGrpc.JsonString() { Json = json.ToString() },
 
 

--- a/PythonRpcServer/ffmpeg.py
+++ b/PythonRpcServer/ffmpeg.py
@@ -1,11 +1,13 @@
 from ffmpy import FFmpeg
 from utils import getTmpFile
 
-def convertVideoToWav(input_filepath):
+def convertVideoToWavWithOffset(input_filepath, offset):
+    if offset is None:
+        offset = 0.0
     output_filepath = getTmpFile()
     ext = '.wav'
     ff = FFmpeg(
-    inputs={input_filepath: None},
+    inputs={input_filepath: '-ss {}'.format(offset)},
     outputs={output_filepath: '-c:a pcm_s16le -ac 1 -y -ar 16000 -f wav'}
     )
     ff.run()

--- a/PythonRpcServer/server.py
+++ b/PythonRpcServer/server.py
@@ -67,9 +67,9 @@ class PythonServerServicer(ct_pb2_grpc.PythonServerServicer):
         youtubeprovider = YoutubeProvider()
         filePath, ext = youtubeprovider.getMedia(request)
         return ct_pb2.File(filePath = filePath, ext = ext)
-    
-    def ConvertVideoToWavRPC(self, request, context):
-        filePath, ext = ffmpeg.convertVideoToWav(request.filePath)
+
+    def ConvertVideoToWavRPCWithOffset(self, request, context):
+        filePath, ext = ffmpeg.convertVideoToWavWithOffset(request.file.filePath, request.offset)
         return ct_pb2.File(filePath = filePath, ext = ext)
 
     def ProcessVideoRPC(self, request, context):

--- a/PythonRpcServer/youtube.py
+++ b/PythonRpcServer/youtube.py
@@ -16,7 +16,7 @@ class YoutubeProvider(MediaProvider):
     def getPlaylistItems(self, request):
         isChannel = json.loads(request.metadata.json)['isChannel'] == '1'
 
-        medias = self.get_youtube_channel(request.identifier) if isChannel else self.get_youtube_playlist(request.identifier)
+        medias = self.get_youtube_channel(request.Url) if isChannel else self.get_youtube_playlist(request.Url)
         return json.dumps(medias)
 
     def getMedia(self, request):

--- a/PythonRpcServer/youtube.py
+++ b/PythonRpcServer/youtube.py
@@ -3,30 +3,48 @@ from utils import encode, decode, getRandomString, download_file
 import os
 from pytube import YouTube
 import json
-from mediaprovider import  MediaProvider, InvalidPlaylistInfoException
+from mediaprovider import MediaProvider, InvalidPlaylistInfoException
 
 DATA_DIRECTORY = os.getenv('DATA_DIRECTORY')
 YOUTUBE_API_KEY = os.getenv('YOUTUBE_API_KEY')
-YOUTUBE_BASE_URL = 'https://www.googleapis.com/youtube/v3/playlistItems'
+YOUTUBE_PLAYLIST_URL = 'https://www.googleapis.com/youtube/v3/playlistItems'
+YOUTUBE_CHANNELS_URL = 'https://www.googleapis.com/youtube/v3/channels'
+
 
 class YoutubeProvider(MediaProvider):
 
     def getPlaylistItems(self, request):
-        medias = self.get_youtube_playlist(request.Url)
+        isChannel = json.loads(request.metadata.json)['isChannel'] == '1'
+
+        medias = self.get_youtube_channel(request.identifier) if isChannel else self.get_youtube_playlist(request.identifier)
         return json.dumps(medias)
-    
+
     def getMedia(self, request):
         return self.download_youtube_video(request.videoUrl)
 
-    def get_youtube_playlist(self, playlistIdentifier):
+    def get_youtube_channel(self, identifier):
+        request1 = requests.get(YOUTUBE_CHANNELS_URL, params={
+                                'part': 'contentDetails', 'id': identifier, 'key': YOUTUBE_API_KEY})
+        if request1.status_code == 404 or request1.status_code == 500:
+            raise InvalidPlaylistInfoException
+        else:
+            request1.raise_for_status()
+
+        playlistId = request1.json(
+        )['items'][0]['contentDetails']['relatedPlaylists']['uploads']
+        #according to one StackOver and one test, channels-to-playlists can also be converted with string replace  UCXXXX to UUXXXX
+        return self.get_youtube_playlist(playlistId)
+
+    def get_youtube_playlist(self, identifier):
         # LIMITATION: Can download a maximum of 50 videos per playlist.
-        request1 = requests.get(YOUTUBE_BASE_URL,  
-        params =  {        
+
+        request1 = requests.get(YOUTUBE_PLAYLIST_URL,
+            params={
             'part': 'snippet',
-            'playlistId': playlistIdentifier,
+            'playlistId': identifier,
             'key': YOUTUBE_API_KEY,
             'maxResults': 50
-        })
+            })
 
         if request1.status_code == 404 or request1.status_code == 500:
             raise InvalidPlaylistInfoException

--- a/TaskEngine/Program.cs
+++ b/TaskEngine/Program.cs
@@ -84,7 +84,7 @@ namespace TaskEngine
             // Start consuming from all queues.
             serviceProvider.GetService<DownloadPlaylistInfoTask>().Consume();
             serviceProvider.GetService<DownloadMediaTask>().Consume();
-            serviceProvider.GetService<ConvertVideoToWavTask>().Consume();
+            // serviceProvider.GetService<ConvertVideoToWavTask>().Consume();
             serviceProvider.GetService<TranscriptionTask>().Consume();
             serviceProvider.GetService<QueueAwakerTask>().Consume();
             serviceProvider.GetService<GenerateVTTFileTask>().Consume();

--- a/TaskEngine/Program.cs
+++ b/TaskEngine/Program.cs
@@ -42,6 +42,7 @@ namespace TaskEngine
                 .Configure<AppSettings>(configuration)
                 .AddDbContext<CTDbContext>(options => options.UseLazyLoadingProxies().UseNpgsql(CTDbContext.ConnectionStringBuilder()))
                 .AddSingleton<RabbitMQConnection>()
+                .AddSingleton<CaptionQueries>()
                 .AddSingleton<DownloadPlaylistInfoTask>()
                 .AddSingleton<DownloadMediaTask>()
                 .AddSingleton<ConvertVideoToWavTask>()
@@ -62,7 +63,7 @@ namespace TaskEngine
 
             _serviceProvider = serviceProvider;
             _logger = serviceProvider.GetRequiredService<ILogger<Program>>();
-            
+
             Globals.appSettings = serviceProvider.GetService<IOptions<AppSettings>>().Value;
             TaskEngineGlobals.KeyProvider = new KeyProvider(Globals.appSettings);
 
@@ -92,13 +93,17 @@ namespace TaskEngine
             serviceProvider.GetService<UpdateBoxTokenTask>().Consume();
             serviceProvider.GetService<CreateBoxTokenTask>().Consume();
 
-            // TempCode tempCode = serviceProvider.GetService<TempCode>();            
-            // tempCode.Temp();
-
+            bool hacktest = false;
+            if (hacktest)
+            {
+                TempCode tempCode = serviceProvider.GetService<TempCode>();
+                tempCode.Temp();
+                return;
+            }
             _logger.LogInformation("All done!");
 
             QueueAwakerTask queueAwakerTask = serviceProvider.GetService<QueueAwakerTask>();
-                        
+
             var timeInterval = new TimeSpan(5, 0, 0);
 
             // Check for new tasks every "timeInterval".

--- a/TaskEngine/Tasks/ConvertVideoToWavTask.cs
+++ b/TaskEngine/Tasks/ConvertVideoToWavTask.cs
@@ -33,9 +33,9 @@ namespace TaskEngine.Tasks
                 var video = await _context.Videos.FindAsync(videoId);
                 _logger.LogInformation("Consuming" + video);
                 // Make RPC call to produce audio file.
-                var file = await _rpcClient.PythonServerClient.ConvertVideoToWavRPCAsync(new CTGrpc.File
+                var file = await _rpcClient.PythonServerClient.ConvertVideoToWavRPCWithOffsetAsync(new CTGrpc.FileForConversion
                 {
-                    FilePath = video.Video1.VMPath
+                    File = new CTGrpc.File{ FilePath = video.Video1.VMPath }
                 });
 
 

--- a/TaskEngine/Tasks/DownloadMediaTask.cs
+++ b/TaskEngine/Tasks/DownloadMediaTask.cs
@@ -18,18 +18,18 @@ namespace TaskEngine.Tasks
     class DownloadMediaTask : RabbitMQTask<string>
     {
         private readonly RpcClient _rpcClient;
-        private readonly ConvertVideoToWavTask _convertVideoToWavTask;
+        private readonly TranscriptionTask _transcriptionTask;
         private readonly ProcessVideoTask _processVideoTask;
         private readonly BoxAPI _box;
         private readonly SlackLogger _slack;
 
         public DownloadMediaTask(RabbitMQConnection rabbitMQ, RpcClient rpcClient,
-            ConvertVideoToWavTask convertVideoToWavTask, ProcessVideoTask processVideoTask, BoxAPI box,
+            TranscriptionTask transcriptionTask, ProcessVideoTask processVideoTask, BoxAPI box,
             ILogger<DownloadMediaTask> logger, SlackLogger slack)
             : base(rabbitMQ, TaskType.DownloadMedia, logger)
         {
             _rpcClient = rpcClient;
-            _convertVideoToWavTask = convertVideoToWavTask;
+            _transcriptionTask = transcriptionTask;
             _processVideoTask = processVideoTask;
             _box = box;
             _slack = slack;
@@ -76,7 +76,7 @@ namespace TaskEngine.Tasks
                         latestMedia.VideoId = video.Id;
                         await _context.SaveChangesAsync();
                         _logger.LogInformation("Downloaded:" + video);
-                        _convertVideoToWavTask.Publish(video.Id);
+                        _transcriptionTask.Publish(video.Id);
                         _processVideoTask.Publish(video.Id);
                     }
                     else
@@ -94,7 +94,7 @@ namespace TaskEngine.Tasks
                             latestMedia.VideoId = video.Id;
                             await _context.SaveChangesAsync();
                             _logger.LogInformation("Downloaded:" + video);
-                            _convertVideoToWavTask.Publish(video.Id);
+                            _transcriptionTask.Publish(video.Id);
                             _processVideoTask.Publish(video.Id);
                         }
                         // If video and file both exist.

--- a/TaskEngine/Tasks/DownloadPlaylistInfoTask.cs
+++ b/TaskEngine/Tasks/DownloadPlaylistInfoTask.cs
@@ -64,7 +64,7 @@ namespace TaskEngine.Tasks
             {
                 jsonString = await _rpcClient.PythonServerClient.GetKalturaChannelEntriesRPCAsync(new CTGrpc.PlaylistRequest
                 {
-                    Identifier = playlist.PlaylistIdentifier
+                    Url = playlist.PlaylistIdentifier
                 });
             }
             catch (RpcException e)
@@ -114,7 +114,7 @@ namespace TaskEngine.Tasks
             {
                 jsonString = await _rpcClient.PythonServerClient.GetEchoPlaylistRPCAsync(new CTGrpc.PlaylistRequest
                 {
-                    Identifier = playlist.PlaylistIdentifier,
+                    Url = playlist.PlaylistIdentifier,
                     Stream = 0
                 });
             }
@@ -186,7 +186,7 @@ namespace TaskEngine.Tasks
             {
                 jsonString = await _rpcClient.PythonServerClient.GetYoutubePlaylistRPCAsync(new CTGrpc.PlaylistRequest
                 {
-                    Identifier = playlist.PlaylistIdentifier,
+                    Url = playlist.PlaylistIdentifier,
                     Metadata = metadata
                 });
             }

--- a/TaskEngine/Tasks/DownloadPlaylistInfoTask.cs
+++ b/TaskEngine/Tasks/DownloadPlaylistInfoTask.cs
@@ -64,7 +64,7 @@ namespace TaskEngine.Tasks
             {
                 jsonString = await _rpcClient.PythonServerClient.GetKalturaChannelEntriesRPCAsync(new CTGrpc.PlaylistRequest
                 {
-                    Url = playlist.PlaylistIdentifier
+                    Identifier = playlist.PlaylistIdentifier
                 });
             }
             catch (RpcException e)
@@ -114,7 +114,7 @@ namespace TaskEngine.Tasks
             {
                 jsonString = await _rpcClient.PythonServerClient.GetEchoPlaylistRPCAsync(new CTGrpc.PlaylistRequest
                 {
-                    Url = playlist.PlaylistIdentifier,
+                    Identifier = playlist.PlaylistIdentifier,
                     Stream = 0
                 });
             }
@@ -178,11 +178,16 @@ namespace TaskEngine.Tasks
         {
             List<Media> newMedia = new List<Media>();
             CTGrpc.JsonString jsonString = null;
+            CTGrpc.JsonString metadata = new CTGrpc.JsonString
+            {
+                Json = playlist.JsonMetadata != null ? playlist.JsonMetadata.ToString() : ""
+            };
             try
             {
                 jsonString = await _rpcClient.PythonServerClient.GetYoutubePlaylistRPCAsync(new CTGrpc.PlaylistRequest
                 {
-                    Url = playlist.PlaylistIdentifier
+                    Identifier = playlist.PlaylistIdentifier,
+                    Metadata = metadata
                 });
             }
             catch (RpcException e)

--- a/TaskEngine/Tasks/QueueAwakerTask.cs
+++ b/TaskEngine/Tasks/QueueAwakerTask.cs
@@ -127,7 +127,7 @@ namespace TaskEngine.Tasks
                 //// Videos which haven't been converted to wav 
                 //(await context.Videos.Where(v => v.Medias.Any() && v.Audio == null).ToListAsync()).ForEach(v => _convertVideoToWavTask.Publish(v.Id));
                 // Videos which have failed in transcribing
-                (await context.Videos.Where(v => v.TranscribingAttempts < 3 && v.TranscriptionStatus != "NoError" && v.Medias.Any() && v.Audio != null)
+                (await context.Videos.Where(v => v.TranscribingAttempts < 3 && v.TranscriptionStatus != "NoError" && v.Medias.Any())
                     .ToListAsync()).ForEach(v => _transcriptionTask.Publish(v.Id));
                 // Completed Transcriptions which haven't generated vtt files
                 (await context.Transcriptions.Where(t => t.Captions.Count > 0 && t.File == null)

--- a/TaskEngine/Tasks/QueueAwakerTask.cs
+++ b/TaskEngine/Tasks/QueueAwakerTask.cs
@@ -17,7 +17,7 @@ namespace TaskEngine.Tasks
     {
         private readonly DownloadPlaylistInfoTask _downloadPlaylistInfoTask;
         private readonly DownloadMediaTask _downloadMediaTask;
-        private readonly ConvertVideoToWavTask _convertVideoToWavTask;
+        // private readonly ConvertVideoToWavTask _convertVideoToWavTask;
         private readonly TranscriptionTask _transcriptionTask;
         private readonly GenerateVTTFileTask _generateVTTFileTask;
         private readonly ProcessVideoTask _processVideoTask;
@@ -29,7 +29,7 @@ namespace TaskEngine.Tasks
         public QueueAwakerTask() { }
 
         public QueueAwakerTask(RabbitMQConnection rabbitMQ, DownloadPlaylistInfoTask downloadPlaylistInfoTask,
-            DownloadMediaTask downloadMediaTask, ConvertVideoToWavTask convertVideoToWavTask,
+            DownloadMediaTask downloadMediaTask,
             TranscriptionTask transcriptionTask, ProcessVideoTask processVideoTask,
             GenerateVTTFileTask generateVTTFileTask, SceneDetectionTask scenedDetectionTask,
             CreateBoxTokenTask createBoxTokenTask, UpdateBoxTokenTask updateBoxTokenTask,
@@ -38,7 +38,7 @@ namespace TaskEngine.Tasks
         {
             _downloadPlaylistInfoTask = downloadPlaylistInfoTask;
             _downloadMediaTask = downloadMediaTask;
-            _convertVideoToWavTask = convertVideoToWavTask;
+            //_convertVideoToWavTask = convertVideoToWavTask;
             _transcriptionTask = transcriptionTask;
             _generateVTTFileTask = generateVTTFileTask;
             _processVideoTask = processVideoTask;
@@ -124,8 +124,8 @@ namespace TaskEngine.Tasks
             {
                 // Medias for which no videos have downloaded
                 (await context.Medias.Where(m => m.Video == null).ToListAsync()).ForEach(m => _downloadMediaTask.Publish(m.Id));
-                // Videos which haven't been converted to wav 
-                (await context.Videos.Where(v => v.Medias.Any() && v.Audio == null).ToListAsync()).ForEach(v => _convertVideoToWavTask.Publish(v.Id));
+                //// Videos which haven't been converted to wav 
+                //(await context.Videos.Where(v => v.Medias.Any() && v.Audio == null).ToListAsync()).ForEach(v => _convertVideoToWavTask.Publish(v.Id));
                 // Videos which have failed in transcribing
                 (await context.Videos.Where(v => v.TranscribingAttempts < 3 && v.TranscriptionStatus != "NoError" && v.Medias.Any() && v.Audio != null)
                     .ToListAsync()).ForEach(v => _transcriptionTask.Publish(v.Id));
@@ -191,12 +191,12 @@ namespace TaskEngine.Tasks
                     var media = await _context.Medias.FindAsync(mediaId);
                     _downloadMediaTask.Publish(media.Id);
                 }
-                else if (type == TaskType.ConvertMedia.ToString())
-                {
-                    var videoId = jObject["videoId"].ToString();
-                    var video = await _context.Videos.FindAsync(videoId);
-                    _convertVideoToWavTask.Publish(video.Id);
-                }
+                //else if (type == TaskType.ConvertMedia.ToString())
+                //{
+                //    var videoId = jObject["videoId"].ToString();
+                //    var video = await _context.Videos.FindAsync(videoId);
+                //    _convertVideoToWavTask.Publish(video.Id);
+                //}
                 else if (type == TaskType.Transcribe.ToString())
                 {
                     var videoId = jObject["videoId"].ToString();

--- a/TaskEngine/TempCode.cs
+++ b/TaskEngine/TempCode.cs
@@ -108,8 +108,24 @@ namespace TaskEngine
         {
             // A dummy awaited function call.
             await Task.Delay(0);
-            // Add any temporary code.
+            // Add any temporary code
+        }
 
-        }        
+        private async Task TestYoutubeChannelDownload()
+        {
+            Playlist p = new Playlist
+            {
+                JsonMetadata = new JObject
+                {
+                    {"isChannel","1" }
+                },
+                PlaylistIdentifier = "UCi8e0iOVk1fEOogdfu4YgfA" // change me - too many videos
+            };
+            context.Playlists.Add(p);
+            await context.SaveChangesAsync();
+            //p.Id = "72336862-244c-4904-a753-2f620ae99633";
+            _downloadPlaylistInfoTask.Publish(p.Id);
+
+        }
     }
 }

--- a/ct.proto
+++ b/ct.proto
@@ -14,8 +14,8 @@ service PythonServer {
   rpc GetYoutubePlaylistRPC (PlaylistRequest) returns (JsonString) {}
   rpc DownloadYoutubeVideoRPC (MediaRequest) returns (File) {}
 
-  rpc ConvertVideoToWavRPC (File) returns (File) {}
-  rpc ProcessVideoRPC (File) returns (File) {}  
+  rpc ConvertVideoToWavRPCWithOffset (FileForConversion) returns (File) {}
+  rpc ProcessVideoRPC (File) returns (File) {}
 }
 
 // The request message containing the user's name.
@@ -25,22 +25,28 @@ message JsonString {
 
 // The response message containing the greetings.
 message PlaylistRequest {
-  string Url = 1;
-  int32 Stream = 2;  
+  string identifier = 1;
+  int32 stream = 2;  
+  JsonString metadata = 3;
 }
 
 message MediaRequest {
-	string videoUrl = 1;
-	string additionalInfo = 2;
+  string videoUrl = 1;
+  string additionalInfo = 2;
 }
 
 message File {
-	string filePath = 1;
+  string filePath = 1;
   string ext = 2;
 }
 
+message FileForConversion {
+  File file = 1;
+  float offset = 2;
+}
+
 message EPubData {
-	string title = 1;
+  string title = 1;
   string author = 2;
   string publisher = 3;
   repeated EPubChapter chapters = 4;
@@ -48,7 +54,7 @@ message EPubData {
 }
 
 message EPubChapter {
-    string title = 1;
-    string text = 2;
-    File image = 3;
+  string title = 1;
+  string text = 2;
+  File image = 3;
 }

--- a/ct.proto
+++ b/ct.proto
@@ -25,7 +25,7 @@ message JsonString {
 
 // The response message containing the greetings.
 message PlaylistRequest {
-  string identifier = 1;
+  string Url = 1;
   int32 stream = 2;  
   JsonString metadata = 3;
 }


### PR DESCRIPTION
Allow deleted entries to be readded without seeing key conflicts. This was done by adding a "DeletedAt" column to every table and forming a unique index with the keys of the table. For example, if the alternate key of the table was {CourseId, OfferingId}, then I am now replacing it with the unique index {CourseId, OfferingId, DeletedAt}. The default value (when IsDeleted = 0) for DeletedAt is 1900-01-01 00:00:00.

Say we add an entry {CourseId = a, OfferingId = 1, IsDeleted = 0, DeletedAt = 1900-01-01 00:00:00}. If we now soft-delete the entry, it will become {CourseId = a, OfferingId = 1, IsDeleted = 1, DeletedAt = [TimeOfDeletion]}. Adding back the entry will we see {CourseId = a, OfferingId = 1, IsDeleted = 0, DeletedAt = 1900-01-01 00:00:00}, which does not conflict with the old deleted entry. When this new entry is deleted again, the time of deletion will be able to distinguish itself with previous deleted entries, so still no conflicts.