### PR TITLE
Filter out null medias for GetAllWatchedMediaForUser

### DIFF
--- a/ClassTranscribeServer/Controllers/WatchHistoriesController.cs
+++ b/ClassTranscribeServer/Controllers/WatchHistoriesController.cs
@@ -61,7 +61,7 @@ namespace ClassTranscribeServer.Controllers
             if (user != null)
             {
                 var watchedMedias = await _context.WatchHistories
-                    .Where(w => w.ApplicationUserId == user.Id)
+                    .Where(w => w.ApplicationUserId == user.Id && w.Media.Id != null)
                     .Select(w => new MediaDTO
                     {
                         Id = w.Media.Id,


### PR DESCRIPTION
Fixes #78 

Simple fix for filtering out deleted medias in `/api/WatchHistories/GetAllWatchedMediaForUser`.

Example result with the fix:
```
[
    {
        "id": "ba7d8b17-98f6-4b3f-8d67-70783f61062d",
        "playlistId": "df4dad4a-296a-4442-80c7-b990b35361a4",
        "createdAt": "2020-09-05T19:35:48.965971",
        "jsonMetadata": {
            "video1": "{\"ContentDisposition\":\"form-data; name=\\\"video1\\\"; filename=\\\"test.mp4\\\"\",\"ContentType\":\"video/mp4\",\"Headers\":{\"Content-Disposition\":[\"form-data; name=\\\"video1\\\"; filename=\\\"test.mp4\\\"\"],\"Content-Type\":[\"video/mp4\"]},\"Length\":4278615,\"Name\":\"video1\",\"FileName\":\"test.mp4\"}",
            "video1Path": "/Users/asherdale/dev/Deployment/test_data/data/1JX11BJG"
        },
        "sourceType": 2,
        "ready": false,
        "video": null,
        "transcriptions": null,
        "name": "test",
        "index": 0,
        "watchHistory": {
            "mediaId": "ba7d8b17-98f6-4b3f-8d67-70783f61062d",
            "applicationUserId": "99",
            "json": {
                "timestamp": 23.259549,
                "ratio": 33.217487361115076
            },
            "id": "0349d7d4-e4c5-4d27-9f69-eeddcac9f4bc"
        }
    }
]
```

Example result without the fix:
```
[
    {
        "id": null,
        "playlistId": null,
        "createdAt": "0001-01-01T00:00:00",
        "jsonMetadata": null,
        "sourceType": 0,
        "ready": false,
        "video": null,
        "transcriptions": null,
        "name": null,
        "index": 0,
        "watchHistory": {
            "mediaId": "112036e0-8dc3-4814-a6fe-aa7bf6daec07",
            "applicationUserId": "99",
            "json": {
                "timestamp": 16.7662,
                "ratio": 23.938718981124534
            },
            "id": "c6ea49dc-c431-4d64-a8d2-27af2a074f27"
        }
    },
    {
        "id": "ba7d8b17-98f6-4b3f-8d67-70783f61062d",
        "playlistId": "df4dad4a-296a-4442-80c7-b990b35361a4",
        "createdAt": "2020-09-05T19:35:48.965971",
        "jsonMetadata": {
            "video1": "{\"ContentDisposition\":\"form-data; name=\\\"video1\\\"; filename=\\\"test.mp4\\\"\",\"ContentType\":\"video/mp4\",\"Headers\":{\"Content-Disposition\":[\"form-data; name=\\\"video1\\\"; filename=\\\"test.mp4\\\"\"],\"Content-Type\":[\"video/mp4\"]},\"Length\":4278615,\"Name\":\"video1\",\"FileName\":\"test.mp4\"}",
            "video1Path": "/Users/asherdale/dev/Deployment/test_data/data/1JX11BJG"
        },
        "sourceType": 2,
        "ready": false,
        "video": null,
        "transcriptions": null,
        "name": "test",
        "index": 0,
        "watchHistory": {
            "mediaId": "ba7d8b17-98f6-4b3f-8d67-70783f61062d",
            "applicationUserId": "99",
            "json": {
                "timestamp": 23.259549,
                "ratio": 33.217487361115076
            },
            "id": "0349d7d4-e4c5-4d27-9f69-eeddcac9f4bc"
        }
    },
    {
        "id": null,
        "playlistId": null,
        "createdAt": "0001-01-01T00:00:00",
        "jsonMetadata": null,
        "sourceType": 0,
        "ready": false,
        "video": null,
        "transcriptions": null,
        "name": null,
        "index": 0,
        "watchHistory": {
            "mediaId": "2e18ea42-8523-4361-b001-575681ff21a3",
            "applicationUserId": "99",
            "json": {
                "timestamp": 257.243118,
                "ratio": 84.19845443833465
            },
            "id": "775c6f4a-9285-429b-bd94-5941677cd271"
        }
    },
    {
        "id": null,
        "playlistId": null,
        "createdAt": "0001-01-01T00:00:00",
        "jsonMetadata": null,
        "sourceType": 0,
        "ready": false,
        "video": null,
        "transcriptions": null,
        "name": null,
        "index": 0,
        "watchHistory": {
            "mediaId": "2e18ea42-8523-4361-b001-575681ff21a3",
            "applicationUserId": "99",
            "json": {
                "timestamp": 17.000343,
                "ratio": 5.564396111547526
            },
            "id": "30ed924e-c89f-4953-af2b-d1a59d6bbe3e"
        }
    }
]
```