### PR TITLE
Add unit testing based on EF in-memory DB

### DIFF
--- a/ClassTranscribeServer.sln
+++ b/ClassTranscribeServer.sln
@@ -26,6 +26,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ClientSdk", "ClientSdk\Clie
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ApiTest", "ApiTest\ApiTest.csproj", "{04B293BD-A36F-4562-9F8A-EED7E47E95FE}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UnitTests", "UnitTests\UnitTests.csproj", "{E944DD15-8FC0-481D-8B79-ACC0D092296E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -60,6 +62,10 @@ Global
 		{04B293BD-A36F-4562-9F8A-EED7E47E95FE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{04B293BD-A36F-4562-9F8A-EED7E47E95FE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{04B293BD-A36F-4562-9F8A-EED7E47E95FE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E944DD15-8FC0-481D-8B79-ACC0D092296E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E944DD15-8FC0-481D-8B79-ACC0D092296E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E944DD15-8FC0-481D-8B79-ACC0D092296E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E944DD15-8FC0-481D-8B79-ACC0D092296E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/UnitTests/ControllerTests/BaseControllerTest.cs
+++ b/UnitTests/ControllerTests/BaseControllerTest.cs
@@ -1,0 +1,37 @@
+﻿using ClassTranscribeDatabase;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+
+namespace UnitTests.ControllerTests
+{
+    public class BaseControllerTest : IDisposable
+    {
+        public CTDbContext _context;
+
+        // This constructor is run before every test, ensuring a new context and in-memory DB for each test case
+        // https://xunit.net/docs/shared-context
+        public BaseControllerTest()
+        {
+            // Create a fresh service provider, and therefore a fresh InMemory database instance
+            var serviceProvider = new ServiceCollection()
+                .AddEntityFrameworkInMemoryDatabase()
+                .BuildServiceProvider();
+
+            // Set up CTDbContext with an in-memory database
+            var optionsBuilder = new DbContextOptionsBuilder<CTDbContext>()
+                .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+                .UseInternalServiceProvider(serviceProvider);
+
+            _context = new CTDbContext(optionsBuilder.Options, null);
+            _context.Database.EnsureDeleted();
+            _context.Database.EnsureCreated();
+        }
+
+        public void Dispose()
+        {
+            _context.Database.EnsureDeleted();
+            _context.Dispose();
+        }
+    }
+}

--- a/UnitTests/ControllerTests/CoursesControllerTest.cs
+++ b/UnitTests/ControllerTests/CoursesControllerTest.cs
@@ -1,0 +1,146 @@
+﻿using ClassTranscribeDatabase.Models;
+using ClassTranscribeServer.Controllers;
+using Microsoft.AspNetCore.Mvc;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace UnitTests.ControllerTests
+{
+    public class CoursesControllerTest : BaseControllerTest
+    {
+        CoursesController _controller;
+
+        public CoursesControllerTest() : base()
+        {
+            _controller = new CoursesController(_context, null);
+        }
+
+        [Fact]
+        public async Task Basic_Post_Put_Get_Course()
+        {
+            var course = new Course
+            {
+                CourseNumber = "241",
+                DepartmentId = "0000"
+            };
+
+            var postResult = await _controller.PostCourse(course);
+            var createdResult = postResult.Result as CreatedAtActionResult;
+
+            Assert.NotNull(createdResult);
+
+            var getResult = await _controller.GetCourse(course.Id);
+
+            Assert.NotNull(getResult.Value);
+            Assert.Equal(course, getResult.Value);
+
+            course.CourseNumber = "new title";
+
+            var putResult = await _controller.PutCourse(course.Id, course);
+            var noContentResult = putResult as NoContentResult;
+
+            Assert.NotNull(noContentResult);
+
+            getResult = await _controller.GetCourse(course.Id);
+
+            Assert.NotNull(getResult.Value);
+            Assert.Equal(course, getResult.Value);
+        }
+
+        [Fact]
+        public async Task Basic_Post_And_Delete_Course()
+        {
+            var course = new Course
+            {
+                CourseNumber = "241",
+                DepartmentId = "0000"
+            };
+
+            var postResult = await _controller.PostCourse(course);
+            var createdResult = postResult.Result as CreatedAtActionResult;
+
+            Assert.NotNull(createdResult);
+
+            var deleteResult = await _controller.DeleteCourse(course.Id);
+
+            Assert.NotNull(deleteResult.Value);
+            Assert.Equal(course, deleteResult.Value);
+
+            var getResult = await _controller.GetCourse(course.Id);
+
+            Assert.Equal(Status.Deleted, getResult.Value.IsDeletedStatus);
+        }
+
+        [Fact]
+        public async Task Get_Courses_By_Department()
+        {
+            var courses = new List<Course> {
+                new Course
+                {
+                    CourseNumber = "101",
+                    DepartmentId = "0001"
+                },
+                new Course
+                {
+                    CourseNumber = "102",
+                    DepartmentId = "2222"
+                },
+                new Course
+                {
+                    CourseNumber = "103",
+                    DepartmentId = "0001"
+                }
+            };
+
+            foreach (var course in courses)
+            {
+                var postResult = await _controller.PostCourse(course);
+                var createdResult = postResult.Result as CreatedAtActionResult;
+
+                Assert.NotNull(createdResult);
+            }
+
+            var getResult = await _controller.GetCourses(courses[0].DepartmentId);
+            List<Course> coursesByDepartment = getResult.Value.ToList();
+
+            Assert.Equal(2, coursesByDepartment.Count);
+            Assert.Equal(courses[0], coursesByDepartment[0]);
+            Assert.Equal(courses[2], coursesByDepartment[1]);
+        }
+
+        [Fact]
+        public async Task Post_Existing_Course()
+        {
+            var course = new Course
+            {
+                CourseNumber = "241",
+                DepartmentId = "0000"
+            };
+
+            var postResult = await _controller.PostCourse(course);
+            var createdResult = postResult.Result as CreatedAtActionResult;
+
+            Assert.NotNull(createdResult);
+
+            var existingCourse = new Course
+            {
+                CourseNumber = "241",
+                DepartmentId = "0000"
+            };
+
+            postResult = await _controller.PostCourse(existingCourse);
+            createdResult = postResult.Result as CreatedAtActionResult;
+            var createdExistingCourse = createdResult.Value as Course;
+
+            Assert.NotNull(createdResult);
+            Assert.Equal(course.Id, createdExistingCourse.Id);
+
+            var getResult = await _controller.GetCourses(course.DepartmentId);
+            List<Course> coursesByDepartment = getResult.Value.ToList();
+
+            Assert.Single(coursesByDepartment);
+        }
+    }
+}

--- a/UnitTests/ControllerTests/CoursesControllerTest.cs
+++ b/UnitTests/ControllerTests/CoursesControllerTest.cs
@@ -141,6 +141,7 @@ namespace UnitTests.ControllerTests
             List<Course> coursesByDepartment = getResult.Value.ToList();
 
             Assert.Single(coursesByDepartment);
+            Assert.Equal(course, coursesByDepartment[0]);
         }
     }
 }

--- a/UnitTests/ControllerTests/EPubsControllerTest.cs
+++ b/UnitTests/ControllerTests/EPubsControllerTest.cs
@@ -1,0 +1,216 @@
+using ClassTranscribeDatabase.Models;
+using ClassTranscribeServer.Controllers;
+using Microsoft.AspNetCore.Mvc;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace UnitTests.ControllerTests
+{
+    public class EPubsControllerTest : BaseControllerTest
+    {
+        EPubsController _controller;
+
+        public EPubsControllerTest() : base()
+        {
+            _controller = new EPubsController(null, _context, null, null);
+        }
+
+        [Fact]
+        public async Task Basic_Post_Put_Get_EPub()
+        {
+            var ePub = new EPub
+            {
+                Title = "example0",
+                Language = "en-US",
+                Filename = "filename_example",
+                Author = "author_example",
+                Publisher = "publisher_example",
+                SourceId = "mediaId_example",
+                SourceType = ResourceType.Media
+            };
+
+            var postResult = await _controller.PostEPub(ePub);
+            var createdResult = postResult.Result as CreatedAtActionResult;
+
+            Assert.NotNull(createdResult);
+
+            var getResult = await _controller.GetEPub(ePub.Id);
+
+            Assert.NotNull(getResult.Value);
+            Assert.Equal(ePub, getResult.Value);
+
+            ePub.Title = "new title";
+
+            var putResult = await _controller.PutEPub(ePub.Id, ePub);
+            var noContentResult = putResult as NoContentResult;
+
+            Assert.NotNull(noContentResult);
+
+            getResult = await _controller.GetEPub(ePub.Id);
+
+            Assert.NotNull(getResult.Value);
+            Assert.Equal(ePub, getResult.Value);
+        }
+
+        [Fact]
+        public async Task Basic_Post_And_Delete_EPub()
+        {
+            var ePub = new EPub
+            {
+                Title = "example0",
+                Language = "en-US",
+                Filename = "filename_example",
+                Author = "author_example",
+                Publisher = "publisher_example",
+                SourceId = "mediaId_example",
+                SourceType = ResourceType.Media
+            };
+
+            var postResult = await _controller.PostEPub(ePub);
+            var createdResult = postResult.Result as CreatedAtActionResult;
+
+            Assert.NotNull(createdResult);
+
+            var deleteResult = await _controller.DeleteEPub(ePub.Id);
+
+            Assert.NotNull(deleteResult.Value);
+            Assert.Equal(ePub, deleteResult.Value);
+
+            var getResult = await _controller.GetEPub(ePub.Id);
+
+            Assert.Equal(Status.Deleted, getResult.Value.IsDeletedStatus);
+        }
+
+        [Fact]
+        public async Task Get_EPubs_By_Source()
+        {
+            var ePubs = new List<EPub> {
+                new EPub
+                {
+                    Title = "example1",
+                    Language = "en-US",
+                    Filename = "filename_example",
+                    Author = "author_example",
+                    Publisher = "publisher_example",
+                    SourceId = "mediaId_example",
+                    SourceType = ResourceType.Media
+                },
+                new EPub
+                {
+                    Title = "example2",
+                    Language = "en-US",
+                    Filename = "filename_example",
+                    Author = "author_example",
+                    Publisher = "publisher_example",
+                    SourceId = "courseId_example",
+                    SourceType = ResourceType.Course
+                },
+                new EPub
+                {
+                    Title = "example3",
+                    Language = "en-US",
+                    Filename = "filename_example",
+                    Author = "author_example",
+                    Publisher = "publisher_example",
+                    SourceId = "mediaId_example",
+                    SourceType = ResourceType.Media
+                }
+            };
+
+            foreach (var ePub in ePubs)
+            {
+                var postResult = await _controller.PostEPub(ePub);
+                var createdResult = postResult.Result as CreatedAtActionResult;
+
+                Assert.NotNull(createdResult);
+            }
+
+            var getResult = await _controller.GetEPubsBySource(ResourceType.Media.ToString(), ePubs[0].SourceId);
+            List<EPub> ePubsBySource = getResult.Value.ToList();
+
+            Assert.Equal(2, ePubsBySource.Count);
+            Assert.Equal(ePubs[0], ePubsBySource[0]);
+            Assert.Equal(ePubs[2], ePubsBySource[1]);
+        }
+
+        [Fact]
+        public async Task Post_Invalid_and_Valid_EPubs()
+        {
+            var ePub = new EPub
+            {
+                Title = "example0",
+                Language = "en-US"
+            };
+
+            var postResult = await _controller.PostEPub(ePub);
+            var badRequestResult = postResult.Result as BadRequestObjectResult;
+
+            Assert.NotNull(badRequestResult);
+
+            ePub.Filename = "filename_example";
+            ePub.Author = "author_example";
+
+            postResult = await _controller.PostEPub(ePub);
+            badRequestResult = postResult.Result as BadRequestObjectResult;
+
+            Assert.NotNull(badRequestResult);
+
+            ePub.Publisher = "publisher_example";
+            ePub.SourceId = "mediaId_example";
+            ePub.SourceType = ResourceType.Media;
+
+            postResult = await _controller.PostEPub(ePub);
+            var createdResult = postResult.Result as CreatedAtActionResult;
+
+            Assert.NotNull(createdResult);
+        }
+
+        [Fact]
+        public async Task Put_Invalid_EPubs()
+        {
+            var ePub = new EPub
+            {
+                Title = "example0",
+                Language = "en-US",
+                Filename = "filename_example",
+                Author = "author_example",
+                Publisher = "publisher_example",
+                SourceId = "mediaId_example",
+                SourceType = ResourceType.Media
+            };
+
+            var postResult = await _controller.PostEPub(ePub);
+            var createdResult = postResult.Result as CreatedAtActionResult;
+
+            Assert.NotNull(createdResult);
+
+            ePub.Title = string.Empty;
+            ePub.Filename = string.Empty;
+
+            var putResult = await _controller.PutEPub(ePub.Id, ePub);
+            var badRequestResult = putResult as BadRequestObjectResult;
+
+            Assert.NotNull(badRequestResult);
+
+            ePub.Title = "example0";
+            ePub.Filename = "filename_example";
+            ePub.Author = string.Empty;
+            ePub.Publisher = string.Empty;
+
+            putResult = await _controller.PutEPub(ePub.Id, ePub);
+            badRequestResult = putResult as BadRequestObjectResult;
+
+            Assert.NotNull(badRequestResult);
+
+            ePub.Author = "author_example";
+            ePub.Publisher = "publisher_example";
+
+            putResult = await _controller.PutEPub(ePub.Id, ePub);
+            var noContentResult = putResult as NoContentResult;
+
+            Assert.NotNull(noContentResult);
+        }
+    }
+}

--- a/UnitTests/README.md
+++ b/UnitTests/README.md
@@ -1,0 +1,28 @@
+# ClassTranscribeServer Unit Tests
+Our unit tests use the xUnit testing framework (https://xunit.net/).
+
+To remove dependencies on a real database, we use Entity Framework's In-Memory database that they offer for unit testing. You can read more about the in-memory DB (and other options for unit testing) here: https://docs.microsoft.com/en-us/ef/core/miscellaneous/testing/.
+
+## Running
+
+From the `WebAPI` directory, you can run these tests on the command line with:
+```
+dotnet test UnitTests
+```
+
+You can also use the CLI to run specific unit tests (https://docs.microsoft.com/en-us/dotnet/core/testing/selective-unit-tests?pivots=xunit).
+
+You can also run the tests in Visual Studio.
+
+## Unit Tests vs Integration Tests
+Unit tests aim to test small parts of business logic (BL) without any dependencies on other parts of the system (such as a database or data access layer). This is why we use an in-memory DB for mocking the real database and data access layer.
+
+To learn more about unit testing compared to integration testing, look here: https://stackoverflow.com/a/5357837.
+
+Look here for EF core unit testing guidelines: https://docs.microsoft.com/en-us/ef/core/miscellaneous/testing/#unit-testing.
+
+## Architecture
+
+Each controller has its own test class which is a subclass of the `BaseControllerTest`. This base class sets up a new context and In-Memory DB in its constructor.
+
+Following xUnit's built-in parallelism (https://xunit.net/docs/running-tests-in-parallel.html), test cases are run sequentially within any given test class but all test classes are run in parallel. Following xUnit's shared contexts (https://xunit.net/docs/shared-context), the parent test class's constructor is run before every single test case, which ensures that every single test case gets a completely fresh DB (so make sure to not rely on previous test cases when writing a new test).

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="coverlet.collector" Version="1.2.0" />
+    <PackageReference Include="EntityFramework" Version="6.4.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.8" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ClassTranscribeServer\ClassTranscribeServer.csproj" />
+    <ProjectReference Include="..\ClassTranscribeDatabase\ClassTranscribeDatabase.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
This contains a new project titled "UnitTests" for testing business logic without a dependency on a real database or data access layer. To do so, we use an in-memory database provided by EF. More information on EF testing here: https://docs.microsoft.com/en-us/ef/core/miscellaneous/testing/

Look at UnitTests/README.md for more information.