### PR TITLE
Publish video duration in DTO

### DIFF
--- a/ClassTranscribeDatabase/Models/FileRecord.cs
+++ b/ClassTranscribeDatabase/Models/FileRecord.cs
@@ -15,7 +15,9 @@ namespace ClassTranscribeDatabase.Models
     {
         private FileRecord(string path)
         {
+            // See logic in Path setter below. If /data/ is not present in the path then this little statement throws an ArgumentException
             Path = path;
+
             FileName = System.IO.Path.GetFileName(path);
         }
 
@@ -26,6 +28,7 @@ namespace ClassTranscribeDatabase.Models
         /// <param name="ext">Extension of the file</param>
         public static async Task<FileRecord> GetNewFileRecordAsync(string filepath, string ext)
         {
+            
             // Rename file.
             var tmpFile = new FileRecord(filepath);
             var uuid = System.Guid.NewGuid().ToString();

--- a/ClassTranscribeServer/Controllers/MediaController.cs
+++ b/ClassTranscribeServer/Controllers/MediaController.cs
@@ -69,6 +69,7 @@ namespace ClassTranscribeServer.Controllers
                 CreatedAt = media.CreatedAt,
                 JsonMetadata = media.JsonMetadata,
                 SourceType = media.SourceType,
+                Duration = media.Video.Duration,
                 Transcriptions = media.Video.Transcriptions
                 .Select(t => new TranscriptionDTO
                 {

--- a/ClassTranscribeServer/Controllers/PlaylistsController.cs
+++ b/ClassTranscribeServer/Controllers/PlaylistsController.cs
@@ -407,6 +407,8 @@ namespace ClassTranscribeServer.Controllers
         public List<TranscriptionDTO> Transcriptions { get; set; }
         public string Name { get; set; }
         public int Index { get; set; }
+
+        public TimeSpan? Duration { get; set; }
         public WatchHistory WatchHistory { get; set; }
     }
 

--- a/UnitTests/ControllerTests/BaseControllerTest.cs
+++ b/UnitTests/ControllerTests/BaseControllerTest.cs
@@ -1,5 +1,7 @@
 ﻿using ClassTranscribeDatabase;
+using ClassTranscribeDatabase.Models;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using System;
 using Xunit;
@@ -11,6 +13,7 @@ namespace UnitTests.ControllerTests
     {
         protected readonly CTDbContext _context;
         protected readonly IAuthorizationService _authorizationService;
+        protected readonly UserManager<ApplicationUser> _userManager;
 
         // This constructor is run before every test, ensuring a new context and in-memory DB for each test case
         // https://xunit.net/docs/shared-context
@@ -22,6 +25,7 @@ namespace UnitTests.ControllerTests
 
             _context = new CTDbContext(optionsBuilder.Options, null);
             _authorizationService = fixture._authorizationService;
+            _userManager = fixture._userManager;
         }
     }
 }

--- a/UnitTests/ControllerTests/ImagesControllerTest.cs
+++ b/UnitTests/ControllerTests/ImagesControllerTest.cs
@@ -3,6 +3,8 @@ using ClassTranscribeDatabase.Models;
 using ClassTranscribeServer.Controllers;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -17,7 +19,9 @@ namespace UnitTests.ControllerTests
 
         public ImagesControllerTest(GlobalFixture fixture) : base(fixture)
         {
-            _controller = new ImagesController(_context, null);
+            ILogger<ImagesController> logger = fixture._serviceProvider.GetService<ILogger<ImagesController>>();
+
+            _controller = new ImagesController(_context,logger);
         }
 
         [Fact]
@@ -41,7 +45,8 @@ namespace UnitTests.ControllerTests
                // 
                // The expected string is missing the extension
                 Assert.Equal(
-                    $"{Globals.appSettings.DATA_DIRECTORY}{createdImage.ImageFileId}",
+                    Path.Combine(Globals.appSettings.DATA_DIRECTORY,createdImage.ImageFileId + ".png"),
+
                     getResult.Value.ImageFile.Path
                 );
 

--- a/UnitTests/ControllerTests/ImagesControllerTest.cs
+++ b/UnitTests/ControllerTests/ImagesControllerTest.cs
@@ -35,6 +35,11 @@ namespace UnitTests.ControllerTests
 
                 var getResult = await _controller.GetImage(createdImage.Id);
                 Assert.Equal(createdImage, getResult.Value);
+                
+               // TODO 
+               // Use Path.Combine - (CrossPlatform + why assume that DATA_DIRECTORY ends with a slash?)
+               // 
+               // The expected string is missing the extension
                 Assert.Equal(
                     $"{Globals.appSettings.DATA_DIRECTORY}{createdImage.ImageFileId}",
                     getResult.Value.ImageFile.Path

--- a/UnitTests/ControllerTests/MediaControllerTest.cs
+++ b/UnitTests/ControllerTests/MediaControllerTest.cs
@@ -1,0 +1,51 @@
+﻿using ClassTranscribeDatabase.Models;
+using ClassTranscribeServer.Controllers;
+using System.Threading.Tasks;
+using Xunit;
+using System;
+using ClassTranscribeServer.Utils;
+
+namespace UnitTests.ControllerTests
+{
+    public class MediaControllerTest : BaseControllerTest
+    {
+        MediaController _controller;
+
+        public MediaControllerTest(GlobalFixture fixture) : base(fixture)
+        {
+
+
+            var userutils = new UserUtils(_userManager, _context);
+            _controller = new MediaController(_authorizationService, null, _context, userutils, null);
+        }
+
+        [Fact]
+        public async Task GetMedia_Returns_Valid_DTO()
+        {
+            var offering = new Offering { Id = "10" };
+            var playlist = new Playlist { OfferingId = offering.Id, Id = "11" };
+            var video = new Video { Duration = TimeSpan.FromSeconds(101), Id = "234" };
+            var media = new Media { VideoId = video.Id, PlaylistId = playlist.Id, Id = "345" };
+            var transcription = new Transcription { Language = "en", VideoId = video.Id, Id = "456" };
+            //  Without at least one transcription media.Video.Transcriptions. is null so Select() throws null exception inside _controller.GetMedia() 
+            //Is this an artefact of the test memorystore?
+
+            _context.Videos.Add(video);
+            _context.Medias.Add(media);
+            _context.Offerings.Add(offering);
+            _context.Playlists.Add(playlist);
+            _context.Transcriptions.Add(transcription);
+            await _context.SaveChangesAsync();
+
+            var mediaDTO = (await _controller.GetMedia(media.Id)).Value;
+            // Check new DTO Duration field
+            Assert.IsType<TimeSpan>(mediaDTO.Duration);
+            Assert.True(mediaDTO.Duration.Equals(video.Duration));
+            // Can add more assertions here in the future
+            Assert.Equal(playlist.Id, mediaDTO.PlaylistId);
+            Assert.Single(mediaDTO.Transcriptions);
+            Assert.Equal(mediaDTO.Id, media.Id);
+        }
+
+    }
+}

--- a/UnitTests/GlobalFixture.cs
+++ b/UnitTests/GlobalFixture.cs
@@ -21,12 +21,17 @@ namespace UnitTests
         public readonly ServiceProvider _serviceProvider;
         public readonly IAuthorizationService _authorizationService;
         public readonly UserManager<ApplicationUser> _userManager;
-        public readonly string _testDataDirectory = "test_data/automatically_deleted/";
+        // 'data' must be exist (and be last). Otherwise FileRecord Path setter will fail
+
+        public readonly string _testDataDirectory = Path.Combine("test_data","automatically_deleted","data");
         // This constructor is run once for all tests in the "Global" collection (which should be all tests)
         // https://xunit.net/docs/shared-context
         public GlobalFixture()
         {
-           
+            if (Directory.Exists(_testDataDirectory))
+            {
+                Directory.Delete(_testDataDirectory, true);
+            }
             Directory.CreateDirectory(_testDataDirectory);
 
             _serviceProvider = new ServiceCollection()

--- a/UnitTests/GlobalFixture.cs
+++ b/UnitTests/GlobalFixture.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
 using RabbitMQ.Client;
@@ -21,9 +22,13 @@ namespace UnitTests
         public readonly ServiceProvider _serviceProvider;
         public readonly IAuthorizationService _authorizationService;
         public readonly UserManager<ApplicationUser> _userManager;
+        public readonly ILogger _logger;
+
+
         // 'data' must be exist (and be last). Otherwise FileRecord Path setter will fail
 
-        public readonly string _testDataDirectory = Path.Combine("test_data","automatically_deleted","data");
+        private static readonly char extraSlash_pleaseMakeMeUnnecessary = Path.DirectorySeparatorChar; // required to make the image tests almost pass, possibly required in the FileREcord Path setter code too
+        private static readonly string _testDataDirectory = Path.Combine("test_data","automatically_deleted","data") + extraSlash_pleaseMakeMeUnnecessary;
         // This constructor is run once for all tests in the "Global" collection (which should be all tests)
         // https://xunit.net/docs/shared-context
         public GlobalFixture()
@@ -39,6 +44,7 @@ namespace UnitTests
                 // Use empty configuration for AppSettings because we do not want
                 // dependencies on any environment variables or vs_appsettings.json
                 .Configure<AppSettings>(new ConfigurationBuilder().Build())
+                .AddLogging(cfg => cfg.AddConsole())
                 .BuildServiceProvider();
 
             Globals.appSettings = _serviceProvider.GetService<IOptions<AppSettings>>().Value;


### PR DESCRIPTION
Since we now have video duration information, we can share that with the webapi in the media DTO (DataTransferObject; just a C# class that is only used to build results to pass to  the frontend - it is not saved in the database)