### PR TITLE
Fixed the bug where we could not switch a student to an instructor…

### DIFF
--- a/ClassTranscribeDatabase/CTDbContext.cs
+++ b/ClassTranscribeDatabase/CTDbContext.cs
@@ -60,7 +60,7 @@ namespace ClassTranscribeDatabase
         public DbSet<Message> Messages { get; set; }
         public DbSet<TaskItem> TaskItems { get; set; }
         public DbSet<Image> Images { get; set; }
-
+        
         /// <summary>
         /// This method builds a connectionstring to connect with the database.
         /// More info, https://www.learnentityframeworkcore.com/connection-strings
@@ -157,6 +157,8 @@ namespace ClassTranscribeDatabase
             // For more info, google "Soft Delete EntityFramework Core"
             //
             // A similar statement must be added for every new table added.
+            // If you decide not to perform soft-delete for a specific table, you should still add the query filter, 
+            // but should also add an "if" clause or equivalent in OnBeforeSaving(). Navigate to this function and see the details.
             builder.Entity<ApplicationUser>().HasQueryFilter(m => m.Status == Status.Active);
             builder.Entity<University>().HasQueryFilter(m => m.IsDeletedStatus == Status.Active);
             builder.Entity<Department>().HasQueryFilter(m => m.IsDeletedStatus == Status.Active);
@@ -178,7 +180,6 @@ namespace ClassTranscribeDatabase
             builder.Entity<Message>().HasQueryFilter(m => m.IsDeletedStatus == Status.Active);
             builder.Entity<EPub>().HasQueryFilter(m => m.IsDeletedStatus == Status.Active);
             builder.Entity<TaskItem>().HasQueryFilter(m => m.IsDeletedStatus == Status.Active);
-
             builder.Entity<Image>().HasQueryFilter(m => m.IsDeletedStatus == Status.Active);
 
             // Configure m-to-n relationships.
@@ -196,7 +197,7 @@ namespace ClassTranscribeDatabase
                 .HasForeignKey(pt => pt.OfferingId);
 
             builder.Entity<UserOffering>()
-            .HasKey(t => new { t.ApplicationUserId, t.OfferingId });
+            .HasKey(t => new { t.ApplicationUserId, t.OfferingId, t.IdentityRoleId });
 
             builder.Entity<UserOffering>()
                 .HasOne(pt => pt.Offering)
@@ -229,7 +230,6 @@ namespace ClassTranscribeDatabase
             builder.Entity<EPub>().Property(m => m.Chapters).HasJsonValueConversion();
             builder.Entity<TaskItem>().Property(m => m.TaskParameters).HasJsonValueConversion();
             builder.Entity<TaskItem>().Property(m => m.ResultData).HasJsonValueConversion();
-
             builder.Entity<TaskItem>().Property(m => m.RemoteResultData).HasJsonValueConversion();
 
 
@@ -250,6 +250,7 @@ namespace ClassTranscribeDatabase
             builder.Entity<TaskItem>().HasAlternateKey(t => new { t.OpaqueMessageRef });
 
         }
+
         public override int SaveChanges(bool acceptAllChangesOnSuccess)
         {
             OnBeforeSaving();
@@ -285,9 +286,16 @@ namespace ClassTranscribeDatabase
                             entity.LastUpdatedAt = now;
                             entity.LastUpdatedBy = user;
                             break;
+
                         case EntityState.Deleted:
-                            entry.State = EntityState.Modified;
-                            entity.IsDeletedStatus = Status.Deleted;
+                            if (entry.Entity is UserOffering)
+                            {
+                                //Do nothing here, do not do soft-delete for this entity.
+                            } else
+                            {
+                                entry.State = EntityState.Modified;
+                                entity.IsDeletedStatus = Status.Deleted;
+                            }
                             break;
                     }
                 }

--- a/ClassTranscribeDatabase/CTDbContext.cs
+++ b/ClassTranscribeDatabase/CTDbContext.cs
@@ -60,7 +60,7 @@ namespace ClassTranscribeDatabase
         public DbSet<Message> Messages { get; set; }
         public DbSet<TaskItem> TaskItems { get; set; }
         public DbSet<Image> Images { get; set; }
-        
+
         /// <summary>
         /// This method builds a connectionstring to connect with the database.
         /// More info, https://www.learnentityframeworkcore.com/connection-strings

--- a/ClassTranscribeDatabase/Migrations/20201113200736_Disable_Soft_Delete_UserOffering.Designer.cs
+++ b/ClassTranscribeDatabase/Migrations/20201113200736_Disable_Soft_Delete_UserOffering.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using ClassTranscribeDatabase;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace ClassTranscribeDatabase.Migrations
 {
     [DbContext(typeof(CTDbContext))]
-    partial class CTDbContextModelSnapshot : ModelSnapshot
+    [Migration("20201113200736_Disable_Soft_Delete_UserOffering")]
+    partial class Disable_Soft_Delete_UserOffering
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/ClassTranscribeDatabase/Migrations/20201113200736_Disable_Soft_Delete_UserOffering.cs
+++ b/ClassTranscribeDatabase/Migrations/20201113200736_Disable_Soft_Delete_UserOffering.cs
@@ -1,0 +1,76 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace ClassTranscribeDatabase.Migrations
+{
+    public partial class Disable_Soft_Delete_UserOffering : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DeleteData(
+                table: "UserOfferings", 
+                keyColumn: "IsDeletedStatus",
+                keyValue: 1
+            );
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_UserOfferings_AspNetRoles_IdentityRoleId",
+                table: "UserOfferings");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_UserOfferings",
+                table: "UserOfferings");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "IdentityRoleId",
+                table: "UserOfferings",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "text",
+                oldNullable: true);
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_UserOfferings",
+                table: "UserOfferings",
+                columns: new[] { "ApplicationUserId", "OfferingId", "IdentityRoleId" });
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_UserOfferings_AspNetRoles_IdentityRoleId",
+                table: "UserOfferings",
+                column: "IdentityRoleId",
+                principalTable: "AspNetRoles",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_UserOfferings_AspNetRoles_IdentityRoleId",
+                table: "UserOfferings");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_UserOfferings",
+                table: "UserOfferings");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "IdentityRoleId",
+                table: "UserOfferings",
+                type: "text",
+                nullable: true,
+                oldClrType: typeof(string));
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_UserOfferings",
+                table: "UserOfferings",
+                columns: new[] { "ApplicationUserId", "OfferingId" });
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_UserOfferings_AspNetRoles_IdentityRoleId",
+                table: "UserOfferings",
+                column: "IdentityRoleId",
+                principalTable: "AspNetRoles",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+    }
+}

--- a/ClassTranscribeServer/Controllers/UserOfferingsController.cs
+++ b/ClassTranscribeServer/Controllers/UserOfferingsController.cs
@@ -94,7 +94,7 @@ namespace ClassTranscribeServer.Controllers
         // DELETE: api/UserOfferings/5
         [HttpDelete("{offeringId}/{userId}")]
         [Authorize]
-        public async Task<ActionResult<UserOffering>> DeleteUserOffering(string offeringId, string userId)
+        public async Task<ActionResult<List<UserOffering>>> DeleteUserOffering(string offeringId, string userId)
         {
             var offering = await _context.Offerings.FindAsync(offeringId);
             if (offering == null)
@@ -113,13 +113,13 @@ namespace ClassTranscribeServer.Controllers
                     return new ChallengeResult();
                 }
             }
-            var userOffering = await _context.UserOfferings.Where(uo => uo.OfferingId == offeringId && uo.ApplicationUserId == userId).FirstAsync();
+            var userOffering = await _context.UserOfferings.Where(uo => uo.OfferingId == offeringId && uo.ApplicationUserId == userId).ToListAsync();
             if (userOffering == null)
             {
                 return NotFound();
             }
 
-            _context.UserOfferings.Remove(userOffering);
+            _context.UserOfferings.RemoveRange(userOffering);
             await _context.SaveChangesAsync();
 
             return userOffering;

--- a/UnitTests/ControllerTests/UserOfferingsControllerTest.cs
+++ b/UnitTests/ControllerTests/UserOfferingsControllerTest.cs
@@ -47,7 +47,7 @@ namespace UnitTests.ControllerTests
             Assert.Equal(Status.Active, getResult.Value.ElementAt(0).IsDeletedStatus);
 
             var deleteResult = await _controller.DeleteUserOffering(offeringId, TestGlobals.TEST_USER_ID);
-            AssertUserOffering(deleteResult.Value, userOfferingDTO);
+            AssertUserOffering(deleteResult.Value[0], userOfferingDTO);
 
             getResult = await _controller.GetUserOfferingsByOfferingId(offeringId);
             Assert.Empty(getResult.Value);
@@ -81,15 +81,8 @@ namespace UnitTests.ControllerTests
             var offeringId = "0001";
             SetupEntities(offeringId);
 
-            var userOfferingDTO = new UserOfferingDTO
-            {
-                OfferingId = offeringId,
-                UserId = TestGlobals.TEST_USER_ID,
-                RoleName = Globals.ROLE_INSTRUCTOR
-            };
-
-            var postResult = await _controller.PostUserOffering(userOfferingDTO);
-            Assert.IsType<CreatedAtActionResult>(postResult.Result);
+            var roles = new List<string>() { Globals.ROLE_INSTRUCTOR };
+            AddUserOfferingsOneToMany(offeringId, TestGlobals.TEST_USER_ID, roles);
 
             List<string> mailIds = new List<string>() { "mailId1@test.edu", "mailId2@test.edu" };
             var addResult = await _controller.AddUsersToOffering(offeringId, Globals.ROLE_INSTRUCTOR, mailIds);
@@ -97,6 +90,105 @@ namespace UnitTests.ControllerTests
 
             var getResult = await _controller.GetUserOfferingsByOfferingId(offeringId);
             Assert.Equal(3, getResult.Value.Count());
+        }
+
+        [Fact]
+        public async Task Add_Multirole_User_To_Offerings()
+        {
+            var offeringId = "0001";
+            SetupEntities(offeringId);
+
+            var roles = new List<string>() { Globals.ROLE_INSTRUCTOR, Globals.ROLE_STUDENT };
+            AddUserOfferingsOneToMany(offeringId, TestGlobals.TEST_USER_ID , roles);
+            var userResult = _context.UserOfferings.Where(u => u.ApplicationUserId == TestGlobals.TEST_USER_ID);
+            Assert.Equal(2, userResult.Count());
+            Assert.Equal(roles, userResult.Select(u => u.IdentityRole.Name).ToList());
+
+            List<string> mailIds = new List<string>() { "mailId1@test.edu" };
+            var addResultInstructor = await _controller.AddUsersToOffering(offeringId, Globals.ROLE_INSTRUCTOR, mailIds);
+            var addResultStudent = await _controller.AddUsersToOffering(offeringId, Globals.ROLE_STUDENT, mailIds);
+            var addResultTA = await _controller.AddUsersToOffering(offeringId, Globals.ROLE_TEACHING_ASSISTANT, mailIds);
+            Assert.Equal(1, addResultInstructor.Value.Count());
+            Assert.Equal(1, addResultStudent.Value.Count());
+            Assert.Equal(1, addResultTA.Value.Count());
+
+            var userId = addResultInstructor.Value.First().ApplicationUserId;
+            var userResult1 = _context.UserOfferings.Where(u => u.ApplicationUserId == userId);
+            Assert.Equal(3, userResult1.Count());
+
+            var getResult = await _controller.GetUserOfferingsByOfferingId(offeringId);
+            Assert.Equal(5, getResult.Value.Count());
+        }
+
+        [Fact]
+        public async Task Add_Samerole_User_To_Offerings()
+        {
+            var offeringId = "0001";
+            SetupEntities(offeringId);
+
+            List<string> mailIds = new List<string>() { "mailId1@test.edu" };
+            var addResultStudent1 = await _controller.AddUsersToOffering(offeringId, Globals.ROLE_STUDENT, mailIds);
+            Assert.Equal(1, addResultStudent1.Value.Count());
+            var addResultStudent = await _controller.AddUsersToOffering(offeringId, Globals.ROLE_STUDENT, mailIds);
+
+            var getResult1 = await _controller.GetUserOfferingsByOfferingId(offeringId);
+            Assert.Equal(1, getResult1.Value.Count());
+        }
+
+        [Fact]
+        public async Task Switch_Student_To_Instructor()
+        {
+            var offeringId = "0001";
+            SetupEntities(offeringId);
+            
+            var email = "mailId1@test.edu";
+            AddUser(email);
+
+            List<string> mailIds = new List<string>() { email };
+            var addResultStudent = await _controller.AddUsersToOffering(offeringId, Globals.ROLE_STUDENT, mailIds);
+            Assert.Equal(1, addResultStudent.Value.Count());
+
+            await _controller.DeleteUserFromOffering(offeringId, Globals.ROLE_STUDENT, mailIds);
+            var getResult = await _controller.GetUserOfferingsByOfferingId(offeringId);
+            Assert.Empty(getResult.Value);
+
+            var addResultInstructor = await _controller.AddUsersToOffering(offeringId, Globals.ROLE_INSTRUCTOR, mailIds);
+            Assert.Equal(1, addResultInstructor.Value.Count());
+
+            var getResult1 = await _controller.GetUserOfferingsByOfferingId(offeringId);
+            Assert.Equal(1, getResult1.Value.Count());
+
+            var userId = addResultInstructor.Value.First().ApplicationUserId;
+            var userResult = _context.UserOfferings.Where(u => u.ApplicationUserId == userId);
+            Assert.Equal(Globals.ROLE_INSTRUCTOR, userResult.First().IdentityRole.Name);
+        }
+
+        [Fact]
+        public async Task Delete_Roles_From_Multirole_User()
+        {
+            var offeringId = "0001";
+            SetupEntities(offeringId);
+            
+            var email = "mailId1@test.edu";
+            AddUser(email);
+
+            List<string> mailIds = new List<string>() { email };
+            var addResultStudent = await _controller.AddUsersToOffering(offeringId, Globals.ROLE_STUDENT, mailIds);
+            var addResultInstructor = await _controller.AddUsersToOffering(offeringId, Globals.ROLE_INSTRUCTOR, mailIds);
+            var addResultTA = await _controller.AddUsersToOffering(offeringId, Globals.ROLE_TEACHING_ASSISTANT, mailIds);
+            var getResult = await _controller.GetUserOfferingsByOfferingId(offeringId);
+            Assert.Equal(3, getResult.Value.Count());
+
+            await _controller.DeleteUserFromOffering(offeringId, Globals.ROLE_STUDENT, mailIds);
+            var getResult1 = await _controller.GetUserOfferingsByOfferingId(offeringId);
+            Assert.Equal(2, getResult1.Value.Count());
+
+            var userResult = _context.UserOfferings.Where(u => u.ApplicationUserId == email);
+            Assert.Equal(new List<string>(){Globals.ROLE_INSTRUCTOR, Globals.ROLE_TEACHING_ASSISTANT}, userResult.Select(u => u.IdentityRole.Name).ToList());
+
+            await _controller.DeleteUserOffering(offeringId, email);
+            var getResult2 = await _controller.GetUserOfferingsByOfferingId(offeringId);
+            Assert.Empty(getResult2.Value);
         }
 
         [Fact]
@@ -116,25 +208,43 @@ namespace UnitTests.ControllerTests
             SetupEntities(offeringId);
 
             var userIds = new List<string>() { "example1", "example2" };
-
-            foreach (var userId in userIds)
-            {
-                _context.Users.Add(new ApplicationUser { Id = userId, Email = userId });
-
-                var postResult = await _controller.PostUserOffering(new UserOfferingDTO
-                {
-                    OfferingId = offeringId,
-                    UserId = userId,
-                    RoleName = Globals.ROLE_INSTRUCTOR
-                });
-
-                Assert.IsType<CreatedAtActionResult>(postResult.Result);
-            }
+            var roles = new List<string>() { Globals.ROLE_INSTRUCTOR, Globals.ROLE_INSTRUCTOR };
+            AddUsers(userIds);
+            AddUserOfferingsOneToOne(offeringId, userIds, roles);
 
             var getResult = await _controller.GetUsersOfOffering(offeringId, Globals.ROLE_INSTRUCTOR);
             Assert.Equal(2, getResult.Value.Count());
             Assert.Contains(userIds[0], getResult.Value);
             Assert.Contains(userIds[1], getResult.Value);
+        }
+
+        [Fact]
+        public async Task Get_Users_Of_Offering_Multirole()
+        {
+            var offeringId = "0001";
+            SetupEntities(offeringId);
+
+            var id1 = "example1";
+            var userIds = new List<string>() { id1, "example2", "example3" };
+            var roles = new List<string>() { Globals.ROLE_INSTRUCTOR, Globals.ROLE_INSTRUCTOR, Globals.ROLE_INSTRUCTOR };
+            var multiroles = new List<string>() { Globals.ROLE_STUDENT };
+
+            AddUsers(userIds);
+            AddUserOfferingsOneToOne(offeringId, userIds, roles);
+            AddUserOfferingsOneToMany(offeringId, id1, multiroles);
+            
+            var getResult = await _controller.GetUsersOfOffering(offeringId, Globals.ROLE_INSTRUCTOR);
+            Assert.Equal(3, getResult.Value.Count());
+            Assert.Contains(userIds[0], getResult.Value);
+            Assert.Contains(userIds[1], getResult.Value);
+            Assert.Contains(userIds[2], getResult.Value);
+
+            var getResult1 = await _controller.GetUsersOfOffering(offeringId, Globals.ROLE_STUDENT);
+            Assert.Equal(1, getResult1.Value.Count());
+            Assert.Equal(id1, getResult.Value.First());
+
+            var getResult2 = await _controller.GetUsersOfOffering(offeringId, Globals.ROLE_TEACHING_ASSISTANT);
+            Assert.Empty(getResult2.Value);
         }
 
         [Fact]
@@ -205,11 +315,64 @@ namespace UnitTests.ControllerTests
                 Name = Globals.ROLE_INSTRUCTOR,
                 NormalizedName = Globals.ROLE_INSTRUCTOR.ToUpper()
             };
+
+            IdentityRole studentRole = new IdentityRole
+            {
+                Name = Globals.ROLE_STUDENT,
+                NormalizedName = Globals.ROLE_STUDENT.ToUpper()
+            };
+
+            IdentityRole TARole = new IdentityRole
+            {
+                Name = Globals.ROLE_TEACHING_ASSISTANT,
+                NormalizedName = Globals.ROLE_TEACHING_ASSISTANT.ToUpper()
+            };
+
             _context.Roles.Add(instructorRole);
+            _context.Roles.Add(studentRole);
+            _context.Roles.Add(TARole);
 
             _context.Users.Add(new ApplicationUser { Id = TestGlobals.TEST_USER_ID });
 
             _context.SaveChanges();
+        }
+
+        private void AddUser(string id) {
+            _context.Users.Add(new ApplicationUser { Id = id, Email = id });
+        }
+
+        private void AddUsers(List<string> ids) {
+            foreach (var userId in ids)
+            {
+                AddUser(userId);
+            }
+        }
+
+        private async void AddUserOfferingsOneToOne(string offeringId, List<string> ids, List<string> roles) {
+            Assert.Equal(ids.Count(), roles.Count());
+            for (var i = 0; i < ids.Count(); i++)
+            {
+                var postResult = await _controller.PostUserOffering(new UserOfferingDTO
+                {
+                    OfferingId = offeringId,
+                    UserId = ids[i],
+                    RoleName = roles[i]
+                });
+                Assert.IsType<CreatedAtActionResult>(postResult.Result);
+            }
+        }
+
+        private async void AddUserOfferingsOneToMany(string offeringId, string id, List<string> roles) {
+            for (var i = 0; i < roles.Count(); i++)
+            {
+                var postResult = await _controller.PostUserOffering(new UserOfferingDTO
+                {
+                    OfferingId = offeringId,
+                    UserId = id,
+                    RoleName = roles[i]
+                });
+                Assert.IsType<CreatedAtActionResult>(postResult.Result);
+            }
         }
     }
 }


### PR DESCRIPTION
Disabled soft-delete for UserOfferings.
Changed primary key of UserOfferings to {OfferingId, UserId, RoleId}, which enabled user to have multiple roles.
Added additional tests for UserOfferingController.

Note: Running the new migration code will erase all entries currently soft-deleted in UserOfferings table. This is actually optional. Keeping them will not cause any issue. I just thought if we were to disable soft-delete for this table, there was no reason we should still hold those soft-deleted records.