### PR TITLE
Add publish control for media, playlists, and offerings

### DIFF
--- a/ClassTranscribeDatabase/Migrations/20201201145853_PublishControlForOfferings.Designer.cs
+++ b/ClassTranscribeDatabase/Migrations/20201201145853_PublishControlForOfferings.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using ClassTranscribeDatabase;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace ClassTranscribeDatabase.Migrations
 {
     [DbContext(typeof(CTDbContext))]
-    partial class CTDbContextModelSnapshot : ModelSnapshot
+    [Migration("20201201145853_PublishControlForOfferings")]
+    partial class PublishControlForOfferings
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/ClassTranscribeDatabase/Migrations/20201201145853_PublishControlForOfferings.cs
+++ b/ClassTranscribeDatabase/Migrations/20201201145853_PublishControlForOfferings.cs
@@ -1,0 +1,43 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace ClassTranscribeDatabase.Migrations
+{
+    public partial class PublishControlForOfferings : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsPublished",
+                table: "Playlists",
+                nullable: false,
+                defaultValue: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "IsPublished",
+                table: "Offerings",
+                nullable: false,
+                defaultValue: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "IsPublished",
+                table: "Medias",
+                nullable: false,
+                defaultValue: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsPublished",
+                table: "Playlists");
+
+            migrationBuilder.DropColumn(
+                name: "IsPublished",
+                table: "Offerings");
+
+            migrationBuilder.DropColumn(
+                name: "IsPublished",
+                table: "Medias");
+        }
+    }
+}

--- a/ClassTranscribeDatabase/Models/Models.cs
+++ b/ClassTranscribeDatabase/Models/Models.cs
@@ -191,6 +191,7 @@ namespace ClassTranscribeDatabase.Models
         public string Description { get; set; }
         public JObject JsonMetadata { get; set; }
         public Visibility Visibility { get; set; }
+        public bool IsPublished { get; set; }
     }
 
     public class Playlist : Entity
@@ -206,6 +207,7 @@ namespace ClassTranscribeDatabase.Models
         public JObject JsonMetadata { get; set; }
         public int Index { get; set; }
         public Visibility Visibility { get; set; }
+        public bool IsPublished { get; set; }
     }
 
     public class Media : Entity
@@ -225,6 +227,7 @@ namespace ClassTranscribeDatabase.Models
         public int Index { get; set; }
         public virtual List<WatchHistory> WatchHistories { get; set; }
         public Visibility Visibility { get; set; }
+        public bool IsPublished { get; set; }
     }
 
     public class Transcription : Entity


### PR DESCRIPTION
Fixes #36 

Visibility has already been implemented, so I only need to implement an `IsPublished` boolean for each of the entities. If you think we'd be better off having an enum type for publish control, let me know. I thought a boolean would be best because the only two options I can image are published vs not published.

For all three entities, the default value for `IsPublished` is `true`(you can see this in `ClassTranscribeDatabase/Migrations/20201201145853_PublishControlForOfferings.cs` on lines 13, 19, and 25).

