### PR TITLE
Change "IsPublished" fields to PublishStatus enum

### DIFF
--- a/ClassTranscribeDatabase/Migrations/20201209005506_PublishStatus.Designer.cs
+++ b/ClassTranscribeDatabase/Migrations/20201209005506_PublishStatus.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using ClassTranscribeDatabase;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace ClassTranscribeDatabase.Migrations
 {
     [DbContext(typeof(CTDbContext))]
-    partial class CTDbContextModelSnapshot : ModelSnapshot
+    [Migration("20201209005506_PublishStatus")]
+    partial class PublishStatus
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/ClassTranscribeDatabase/Migrations/20201209005506_PublishStatus.cs
+++ b/ClassTranscribeDatabase/Migrations/20201209005506_PublishStatus.cs
@@ -1,0 +1,107 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace ClassTranscribeDatabase.Migrations
+{
+    public partial class PublishStatus : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsPublished",
+                table: "Playlists");
+
+            migrationBuilder.DropColumn(
+                name: "IsPublished",
+                table: "Offerings");
+
+            migrationBuilder.DropColumn(
+                name: "IsPublished",
+                table: "Medias");
+
+            migrationBuilder.DropColumn(
+                name: "IsPublished",
+                table: "EPubs");
+
+            migrationBuilder.AddColumn<int>(
+                name: "PublishStatus",
+                table: "Playlists",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "PublishStatus",
+                table: "Offerings",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "PublishStatus",
+                table: "Medias",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "PublishStatus",
+                table: "EPubs",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "Visibility",
+                table: "EPubs",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "PublishStatus",
+                table: "Playlists");
+
+            migrationBuilder.DropColumn(
+                name: "PublishStatus",
+                table: "Offerings");
+
+            migrationBuilder.DropColumn(
+                name: "PublishStatus",
+                table: "Medias");
+
+            migrationBuilder.DropColumn(
+                name: "PublishStatus",
+                table: "EPubs");
+
+            migrationBuilder.DropColumn(
+                name: "Visibility",
+                table: "EPubs");
+
+            migrationBuilder.AddColumn<bool>(
+                name: "IsPublished",
+                table: "Playlists",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "IsPublished",
+                table: "Offerings",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "IsPublished",
+                table: "Medias",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "IsPublished",
+                table: "EPubs",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+    }
+}

--- a/ClassTranscribeDatabase/Models/Models.cs
+++ b/ClassTranscribeDatabase/Models/Models.cs
@@ -62,6 +62,12 @@ namespace ClassTranscribeDatabase.Models
         Hidden = 1
     }
 
+    public enum PublishStatus
+    {
+        Published = 0,
+        NotPublished = 1
+    }
+
     /// <summary>
     /// This class represents a User of ClassTranscribe.
     /// </summary>
@@ -197,7 +203,7 @@ namespace ClassTranscribeDatabase.Models
         public string Description { get; set; }
         public JObject JsonMetadata { get; set; }
         public Visibility Visibility { get; set; }
-        public bool IsPublished { get; set; }
+        public PublishStatus PublishStatus { get; set; }
     }
 
     public class Playlist : Entity
@@ -213,7 +219,7 @@ namespace ClassTranscribeDatabase.Models
         public JObject JsonMetadata { get; set; }
         public int Index { get; set; }
         public Visibility Visibility { get; set; }
-        public bool IsPublished { get; set; }
+        public PublishStatus PublishStatus { get; set; }
     }
 
     public class Media : Entity
@@ -233,7 +239,7 @@ namespace ClassTranscribeDatabase.Models
         public int Index { get; set; }
         public virtual List<WatchHistory> WatchHistories { get; set; }
         public Visibility Visibility { get; set; }
-        public bool IsPublished { get; set; }
+        public PublishStatus PublishStatus { get; set; }
     }
 
     public class Transcription : Entity
@@ -397,7 +403,8 @@ namespace ClassTranscribeDatabase.Models
         public string Language { get; set; }
         public string Author { get; set; }
         public string Publisher { get; set; }
-        public bool IsPublished { get; set; }
+        public Visibility Visibility { get; set; }
+        public PublishStatus PublishStatus { get; set; }
         public JObject Cover { get; set; }
         public List<JObject> Chapters { get; set; }
     }

--- a/UnitTests/ControllerTests/EPubsControllerTest.cs
+++ b/UnitTests/ControllerTests/EPubsControllerTest.cs
@@ -44,6 +44,8 @@ namespace UnitTests.ControllerTests
 
             getResult = await _controller.GetEPub(ePub.Id);
             Assert.Equal(ePub, getResult.Value);
+            Assert.Equal(PublishStatus.Published, getResult.Value.PublishStatus);
+            Assert.Equal(Visibility.Visible, getResult.Value.Visibility);
         }
 
         [Fact]

--- a/UnitTests/ControllerTests/MediaControllerTest.cs
+++ b/UnitTests/ControllerTests/MediaControllerTest.cs
@@ -145,6 +145,8 @@ namespace UnitTests.ControllerTests
             Assert.Equal(string.Empty, media.PlaylistId);
             Assert.Equal(SourceType.Local, media.SourceType);
             Assert.Equal(JsonConvert.SerializeObject(videoFile), media.JsonMetadata["video1"]);
+            Assert.Equal(PublishStatus.Published, media.PublishStatus);
+            Assert.Equal(Visibility.Visible, media.Visibility);
         }
 
         [Fact]

--- a/UnitTests/ControllerTests/OfferingsControllerTest.cs
+++ b/UnitTests/ControllerTests/OfferingsControllerTest.cs
@@ -39,6 +39,7 @@ namespace UnitTests.ControllerTests
 
             var offering = new Offering
             {
+                Id = "offering",
                 SectionName = "A",
                 TermId = termId
             };
@@ -59,6 +60,10 @@ namespace UnitTests.ControllerTests
 
             var getResult = await _controller.GetOffering(offering.Id);
             AssertOfferingDTO(getResult.Value, offering, courseId, departmentId);
+
+            var newOffering = _context.Offerings.Find(offering.Id);
+            Assert.Equal(PublishStatus.Published, newOffering.PublishStatus);
+            Assert.Equal(Visibility.Visible, newOffering.Visibility);
         }
 
         [Fact]

--- a/UnitTests/ControllerTests/PlaylistsControllerTest.cs
+++ b/UnitTests/ControllerTests/PlaylistsControllerTest.cs
@@ -296,6 +296,8 @@ namespace UnitTests.ControllerTests
 
             var newPlaylist = _context.Playlists.Find(playlist.Id);
             Assert.Equal(playlist, newPlaylist);
+            Assert.Equal(PublishStatus.Published, playlist.PublishStatus);
+            Assert.Equal(Visibility.Visible, playlist.Visibility);
         }
 
         [Fact]


### PR DESCRIPTION
Using an enum ensures that the default value is 0, which in this case is "Published".

This change was applied to Offerings, Medias, Playlists, and EPubs.

I also added a "Visibility" field to EPubs in case we ever want to use it.