### PR TITLE
Add Bearer authentication check for static file serving

### DIFF
--- a/ClassTranscribeServer/Controllers/StaticFileController.cs
+++ b/ClassTranscribeServer/Controllers/StaticFileController.cs
@@ -57,7 +57,7 @@ namespace ClassTranscribeServer.Controllers
             }
             // Require Authenticated user
             if( ! checkFileAccess(urlsubpath, User ) ) {
-                return Unauthorized();
+                return Forbid();
             }
             var readStream = fileInfo.CreateReadStream();
             var mimeType = "application/octet-stream"; // arbitrary data


### PR DESCRIPTION
Static file requests (mp4, images and vtt files) are considered valid if a valid Bearer token of an authenticated user is supplied.

A referer header  is still supported for now  as a secondary backup validation check but is considered deprecated.
The -dev server also accepts localhost as a valid referer. 