### PR TITLE
MacOS Big Sur fix: update to latest stable versions of Grpc and Google Protobuf

### DIFF
--- a/CTCommons/CTCommons.csproj
+++ b/CTCommons/CTCommons.csproj
@@ -10,9 +10,9 @@
   
   <ItemGroup>
     <PackageReference Include="Box.V2.Core" Version="3.22.0" />
-    <PackageReference Include="Google.Protobuf" Version="3.11.4" />
-    <PackageReference Include="Grpc.Core" Version="2.28.1" />
-    <PackageReference Include="Grpc.Tools" Version="2.28.1">
+    <PackageReference Include="Google.Protobuf" Version="3.17.3" />
+    <PackageReference Include="Grpc.Core" Version="2.39.1" />
+    <PackageReference Include="Grpc.Tools" Version="2.39.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Fixes #170 

As detailed [here](https://github.com/grpc/grpc/issues/24760), this was an issue with Grpc mistakenly detecting macOS Big Sur as linux. It was fixed in Grpc version 2.34, so I just updated the package to the latest stable version (which also required updating the Google Protobuf package).

I am running Big Sur on my laptop, so before this change I was getting errors whenever I would try to build any of the projects. After this change, all of the projects build successfully and I can see that the full-stack CT is running correctly.