### PR TITLE
Hide unpublished offerings in feed

### DIFF
--- a/ClassTranscribeServer/Controllers/OfferingsController.cs
+++ b/ClassTranscribeServer/Controllers/OfferingsController.cs
@@ -37,7 +37,7 @@ namespace ClassTranscribeServer.Controllers
             // Store the results
             List<Offering> offerings = await _context.Offerings.ToListAsync();
 
-            // Include offerings that have existing media items and are published
+            // Only include offerings that have existing media items and are published
             return offerings
                 .FindAll(o => o.Playlists != null && o.Playlists.SelectMany(m => m.Medias).Any() && o.PublishStatus == PublishStatus.Published)
                 .OrderBy(o => o.Term.StartDate)

--- a/ClassTranscribeServer/Controllers/OfferingsController.cs
+++ b/ClassTranscribeServer/Controllers/OfferingsController.cs
@@ -37,9 +37,9 @@ namespace ClassTranscribeServer.Controllers
             // Store the results
             List<Offering> offerings = await _context.Offerings.ToListAsync();
 
-            // Filter out offerings where there is no media items available
+            // Include offerings that have existing media items and are published
             return offerings
-                .FindAll(o => o.Playlists != null && o.Playlists.SelectMany(m => m.Medias).Any())
+                .FindAll(o => o.Playlists != null && o.Playlists.SelectMany(m => m.Medias).Any() && o.PublishStatus == PublishStatus.Published)
                 .OrderBy(o => o.Term.StartDate)
                 .Select(o => GetOfferingDTO(o))
                 .ToList();

--- a/UnitTests/ControllerTests/OfferingsControllerTest.cs
+++ b/UnitTests/ControllerTests/OfferingsControllerTest.cs
@@ -150,12 +150,14 @@ namespace UnitTests.ControllerTests
                 new Offering
                 {
                     SectionName = "B",
-                    TermId = termId
+                    TermId = termId,
+                    PublishStatus = PublishStatus.Published
                 },
                 new Offering
                 {
                     SectionName = "C",
-                    TermId = termId
+                    TermId = termId,
+                    PublishStatus = PublishStatus.NotPublished
                 }
             };
 
@@ -171,13 +173,19 @@ namespace UnitTests.ControllerTests
                 Assert.IsType<CreatedAtActionResult>(postResult.Result);
             }
 
-            var playlist = new Playlist { OfferingId = offerings[1].Id };
-            _context.Playlists.Add(playlist);
-            _context.Medias.Add(new Media { PlaylistId = playlist.Id });
+            var playlistB = new Playlist { OfferingId = offerings[1].Id };
+            _context.Playlists.Add(playlistB);
+            _context.Medias.Add(new Media { PlaylistId = playlistB.Id });
+
+            var playlistC = new Playlist { OfferingId = offerings[2].Id };
+            _context.Playlists.Add(playlistC);
+            _context.Medias.Add(new Media { PlaylistId = playlistC.Id });
 
             var getResult = await _controller.GetOfferingsByStudent();
             List<OfferingDTO> offeringsByStudent = getResult.Value.ToList();
 
+            // Even though playlists B and C both exist with their own medias,
+            // only B should be returned because C is not published
             Assert.Single(offeringsByStudent);
             AssertOfferingDTO(offeringsByStudent[0], offerings[1], courseId, departmentId);
         }


### PR DESCRIPTION
Fixes #167 

This is essentially identical to the first commit from the stale PR #172. @angrave I didn't exactly understand what your concern was about the existing offerings in the DB, as this change doesn't affect the DB at all, it simply filters out any unpublished offerings for this endpoint.

To clarify: the default value for `PublishStatus` in the DB is `Published` for all existing offerings and newly-created offerings. So any offerings that are created by the frontend automatically default to having a `PublishStatus` of `Published` if it is not specified. I confirmed this on my local setup.