### PR TITLE
New Video entities should always have non-null JObject properties

### DIFF
--- a/ClassTranscribeDatabase/Models/Models.cs
+++ b/ClassTranscribeDatabase/Models/Models.cs
@@ -291,8 +291,6 @@ namespace ClassTranscribeDatabase.Models
         public virtual List<Transcription> Transcriptions { get; set; }
 
         public virtual List<EPub> EPubs { get; set; }
-        public JObject SceneData { get; set; }
-        public JObject JsonMetadata { get; set; }
         public string? PhraseHints { get; set; } // null if not yet processed
 
         // Reported duration extracted from MediaInfo. The actual video/audio/caption streams duration could be less
@@ -300,10 +298,11 @@ namespace ClassTranscribeDatabase.Models
         // TimeSpan.Zero means a video that is actually zero seconds
         // See UpdateMediaProperties
         public virtual TimeSpan? Duration { get; set; }
-        
 
+        public JObject SceneData { get; set; } = new JObject();
+        public JObject JsonMetadata { get; set; } = new JObject();
         // MediaInfo extracted from the video file
-        public virtual JObject FileMediaInfo { get; set; }
+        public virtual JObject FileMediaInfo { get; set; } = new JObject();
 
 
         public virtual void UpdateMediaProperties()

--- a/UnitTests/OtherTests/ModelsTests.cs
+++ b/UnitTests/OtherTests/ModelsTests.cs
@@ -1,0 +1,17 @@
+﻿using ClassTranscribeDatabase.Models;
+using Xunit;
+
+namespace UnitTests.OtherTests
+{
+    public class ModelsTests
+    {
+        [Fact]
+        public void Video_JObjects_Not_Null()
+        {
+            var video = new Video();
+            Assert.NotNull(video.JsonMetadata);
+            Assert.NotNull(video.SceneData);
+            Assert.NotNull(video.FileMediaInfo);
+        }
+    }
+}

--- a/UnitTests/OtherTests/ModelsTests.cs
+++ b/UnitTests/OtherTests/ModelsTests.cs
@@ -9,9 +9,14 @@ namespace UnitTests.OtherTests
         public void Video_JObjects_Not_Null()
         {
             var video = new Video();
+
             Assert.NotNull(video.JsonMetadata);
             Assert.NotNull(video.SceneData);
             Assert.NotNull(video.FileMediaInfo);
+
+            Assert.Equal("{}", video.JsonMetadata.ToString());
+            Assert.Equal("{}", video.SceneData.ToString());
+            Assert.Equal("{}", video.FileMediaInfo.ToString());
         }
     }
 }


### PR DESCRIPTION
First part of fixing #52 