### PR TITLE
Remove unused usings across the project and fix misc warnings

### DIFF
--- a/ApiTest/AssertInfo.cs
+++ b/ApiTest/AssertInfo.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 
 namespace Tests
 {
-  public class AssertInfo
+    public class AssertInfo
     {
         public string assert;
         public string expect;

--- a/ApiTest/AssertInfo.cs
+++ b/ApiTest/AssertInfo.cs
@@ -1,16 +1,12 @@
-﻿using JsonDiffPatchDotNet;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
-using System.Text;
 
 
 namespace Tests
 {
-    public class AssertInfo
+  public class AssertInfo
     {
         public string assert;
         public string expect;

--- a/ApiTest/Setting.cs
+++ b/ApiTest/Setting.cs
@@ -6,7 +6,7 @@ using System.Reflection;
 namespace Tests
 {
 
-  class Setting
+    class Setting
     {
         public static JsonSerializerSettings jsonSetting =  new JsonSerializerSettings
         {

--- a/ApiTest/Setting.cs
+++ b/ApiTest/Setting.cs
@@ -1,14 +1,12 @@
 ﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
-using System;
 using System.Collections.Generic;
 using System.Reflection;
-using System.Text;
 
 namespace Tests
 {
 
-    class Setting
+  class Setting
     {
         public static JsonSerializerSettings jsonSetting =  new JsonSerializerSettings
         {

--- a/ApiTest/UnitTest.cs
+++ b/ApiTest/UnitTest.cs
@@ -3,7 +3,7 @@ using System.Collections;
 
 namespace Tests
 {
-  public class Tests
+    public class Tests
     {
         // Inputs: token, api, method, inputs, expected outputs
         public class TestData : IEnumerable<object[]>

--- a/ApiTest/UnitTest.cs
+++ b/ApiTest/UnitTest.cs
@@ -1,12 +1,9 @@
-using System;
-using Xunit;
 using System.Collections.Generic;
-using System.Linq;
 using System.Collections;
 
 namespace Tests
 {
-    public class Tests
+  public class Tests
     {
         // Inputs: token, api, method, inputs, expected outputs
         public class TestData : IEnumerable<object[]>

--- a/ApiTest/Utils.cs
+++ b/ApiTest/Utils.cs
@@ -7,7 +7,7 @@ using System.Globalization;
 namespace Tests
 {
 
-  class Utils
+    class Utils
     {
 
         public static string toTitleCase(string str)

--- a/ApiTest/Utils.cs
+++ b/ApiTest/Utils.cs
@@ -1,15 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
 using JsonDiffPatchDotNet;
-using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System.Globalization;
 
 namespace Tests
 {
 
-    class Utils
+  class Utils
     {
 
         public static string toTitleCase(string str)

--- a/CTCommons/MSTranscription/KeyProvider.cs
+++ b/CTCommons/MSTranscription/KeyProvider.cs
@@ -5,10 +5,10 @@ using System.Linq;
 
 namespace CTCommons.MSTranscription
 {
-  /// <summary>
-  /// Each object of this class represents an azure subscription key.
-  /// </summary>
-  public class Key
+    /// <summary>
+    /// Each object of this class represents an azure subscription key.
+    /// </summary>
+    public class Key
     {
         public string ApiKey { get; set; }
         public string Region { get; set; }

--- a/CTCommons/MSTranscription/KeyProvider.cs
+++ b/CTCommons/MSTranscription/KeyProvider.cs
@@ -2,14 +2,13 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
 
 namespace CTCommons.MSTranscription
 {
-    /// <summary>
-    /// Each object of this class represents an azure subscription key.
-    /// </summary>
-    public class Key
+  /// <summary>
+  /// Each object of this class represents an azure subscription key.
+  /// </summary>
+  public class Key
     {
         public string ApiKey { get; set; }
         public string Region { get; set; }

--- a/CTCommons/MSTranscription/MSTranscriptionService.cs
+++ b/CTCommons/MSTranscription/MSTranscriptionService.cs
@@ -1,5 +1,4 @@
-﻿using ClassTranscribeDatabase;
-using ClassTranscribeDatabase.Models;
+﻿using ClassTranscribeDatabase.Models;
 using Microsoft.CognitiveServices.Speech;
 using Microsoft.CognitiveServices.Speech.Translation;
 using Microsoft.Extensions.Logging;
@@ -8,7 +7,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using static ClassTranscribeDatabase.CommonUtils;
 using CTCommons.Grpc;
 using System.IO;
 
@@ -23,7 +21,7 @@ using System.IO;
 namespace CTCommons.MSTranscription
 {
 
-    public class MSTranscriptionService
+  public class MSTranscriptionService
     {
 
         // Theses were generated manually on 2020/10/1 using curl and some regex replacements in vi

--- a/CTCommons/MSTranscription/MSTranscriptionService.cs
+++ b/CTCommons/MSTranscription/MSTranscriptionService.cs
@@ -21,7 +21,7 @@ using System.IO;
 namespace CTCommons.MSTranscription
 {
 
-  public class MSTranscriptionService
+    public class MSTranscriptionService
     {
 
         // Theses were generated manually on 2020/10/1 using curl and some regex replacements in vi

--- a/CTCommons/Notification.cs
+++ b/CTCommons/Notification.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 
 namespace CTCommons.Notification
 {
-  public class SubscriptionManager
+    public class SubscriptionManager
     {
         private readonly CTDbContext _context;
 

--- a/CTCommons/Notification.cs
+++ b/CTCommons/Notification.cs
@@ -3,15 +3,13 @@ using ClassTranscribeDatabase.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json.Linq;
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace CTCommons.Notification
 {
-    public class SubscriptionManager
+  public class SubscriptionManager
     {
         private readonly CTDbContext _context;
 

--- a/ClassTranscribeDatabase/CommonUtils.cs
+++ b/ClassTranscribeDatabase/CommonUtils.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace ClassTranscribeDatabase
 {
-  public class CommonUtils
+    public class CommonUtils
     {
         // Explicitly number entries because these will exist in the database
         // and we dont want the meaning of existing entries to change due to future modifications of this list

--- a/ClassTranscribeDatabase/CommonUtils.cs
+++ b/ClassTranscribeDatabase/CommonUtils.cs
@@ -1,14 +1,11 @@
-﻿using Microsoft.AspNetCore.Http;
-using Newtonsoft.Json;
-using RabbitMQ.Client.Content;
+﻿using Newtonsoft.Json;
 using System;
 using System.IO;
-using System.Linq;
 using System.Text;
 
 namespace ClassTranscribeDatabase
 {
-    public class CommonUtils
+  public class CommonUtils
     {
         // Explicitly number entries because these will exist in the database
         // and we dont want the meaning of existing entries to change due to future modifications of this list

--- a/ClassTranscribeDatabase/Globals.cs
+++ b/ClassTranscribeDatabase/Globals.cs
@@ -1,13 +1,9 @@
-﻿
-using Microsoft.Extensions.Logging;
-using System.Collections.Generic;
-
-namespace ClassTranscribeDatabase
+﻿namespace ClassTranscribeDatabase
 {
-    /// <summary>
-    /// All the configuration setttins that are supplied either by vs_appsettings.json or by environment variables.
-    /// </summary>
-    public class AppSettings
+  /// <summary>
+  /// All the configuration setttins that are supplied either by vs_appsettings.json or by environment variables.
+  /// </summary>
+  public class AppSettings
     {
         public string JWT_EXPIRE_DAYS { get; set; }
         public string HOST_NAME { get; set; }

--- a/ClassTranscribeDatabase/Globals.cs
+++ b/ClassTranscribeDatabase/Globals.cs
@@ -1,9 +1,9 @@
 ﻿namespace ClassTranscribeDatabase
 {
-  /// <summary>
-  /// All the configuration setttins that are supplied either by vs_appsettings.json or by environment variables.
-  /// </summary>
-  public class AppSettings
+    /// <summary>
+    /// All the configuration setttins that are supplied either by vs_appsettings.json or by environment variables.
+    /// </summary>
+    public class AppSettings
     {
         public string JWT_EXPIRE_DAYS { get; set; }
         public string HOST_NAME { get; set; }

--- a/ClassTranscribeDatabase/Models/Models.cs
+++ b/ClassTranscribeDatabase/Models/Models.cs
@@ -114,7 +114,9 @@ namespace ClassTranscribeDatabase.Models
         public DateTime? DeletedAt { get; set; }
         [SwaggerIgnore]
         [IgnoreDataMember]
+#nullable enable
         public string? DeletedBy { get; set; }
+#nullable disable
 
         public ResourceType GetResourceType()
         {
@@ -291,7 +293,9 @@ namespace ClassTranscribeDatabase.Models
         public virtual List<Transcription> Transcriptions { get; set; }
 
         public virtual List<EPub> EPubs { get; set; }
+#nullable enable
         public string? PhraseHints { get; set; } // null if not yet processed
+#nullable disable
 
         // Reported duration extracted from MediaInfo. The actual video/audio/caption streams duration could be less
         // Returns null if unknown

--- a/ClassTranscribeDatabase/Models/TaskItem.cs
+++ b/ClassTranscribeDatabase/Models/TaskItem.cs
@@ -5,16 +5,16 @@ using static ClassTranscribeDatabase.CommonUtils;
 namespace ClassTranscribeDatabase.Models
 {
 
-  /// <summary>
-  /// A representation of a background job to aid debugging information and provide status information to instructors
-  /// </summary>
-  /// <remarks>
-  /// We dont add a collection of TaskItems to Videos, Playlists etc because the entity framework will then always load these rows
-  /// See https://stackoverflow.com/questions/32273760/can-you-exclude-reverse-navigation-properties-in-ef-when-eager-loading
-  /// 
-  /// </remarks>
+    /// <summary>
+    /// A representation of a background job to aid debugging information and provide status information to instructors
+    /// </summary>
+    /// <remarks>
+    /// We dont add a collection of TaskItems to Videos, Playlists etc because the entity framework will then always load these rows
+    /// See https://stackoverflow.com/questions/32273760/can-you-exclude-reverse-navigation-properties-in-ef-when-eager-loading
+    /// 
+    /// </remarks>
 
-  public class TaskItem : Entity
+    public class TaskItem : Entity
     {
         // e.g. RefreshPlaylist/playlist-id
         // e.g. GenerateCaptions/playlist-uuid

--- a/ClassTranscribeDatabase/Models/TaskItem.cs
+++ b/ClassTranscribeDatabase/Models/TaskItem.cs
@@ -1,26 +1,20 @@
-﻿using Microsoft.AspNetCore.Identity;
-using Microsoft.Extensions.Logging;
-using Newtonsoft.Json.Linq;
+﻿using Newtonsoft.Json.Linq;
 using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations.Schema;
-using System.Runtime.Serialization;
-using System.Threading.Tasks;
 using static ClassTranscribeDatabase.CommonUtils;
 
 namespace ClassTranscribeDatabase.Models
 {
 
-    /// <summary>
-    /// A representation of a background job to aid debugging information and provide status information to instructors
-    /// </summary>
-    /// <remarks>
-    /// We dont add a collection of TaskItems to Videos, Playlists etc because the entity framework will then always load these rows
-    /// See https://stackoverflow.com/questions/32273760/can-you-exclude-reverse-navigation-properties-in-ef-when-eager-loading
-    /// 
-    /// </remarks>
+  /// <summary>
+  /// A representation of a background job to aid debugging information and provide status information to instructors
+  /// </summary>
+  /// <remarks>
+  /// We dont add a collection of TaskItems to Videos, Playlists etc because the entity framework will then always load these rows
+  /// See https://stackoverflow.com/questions/32273760/can-you-exclude-reverse-navigation-properties-in-ef-when-eager-loading
+  /// 
+  /// </remarks>
 
-    public class TaskItem : Entity
+  public class TaskItem : Entity
     {
         // e.g. RefreshPlaylist/playlist-id
         // e.g. GenerateCaptions/playlist-uuid

--- a/ClassTranscribeServer/Controllers/AdminController.cs
+++ b/ClassTranscribeServer/Controllers/AdminController.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace ClassTranscribeServer.Controllers
 {
-  [Route("api/[controller]")]
+    [Route("api/[controller]")]
     [ApiController]
     public class AdminController : BaseController
     {

--- a/ClassTranscribeServer/Controllers/AdminController.cs
+++ b/ClassTranscribeServer/Controllers/AdminController.cs
@@ -1,19 +1,14 @@
 ﻿using ClassTranscribeDatabase;
-using CsvHelper;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json.Linq;
-using System;
-using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 
 namespace ClassTranscribeServer.Controllers
 {
-    [Route("api/[controller]")]
+  [Route("api/[controller]")]
     [ApiController]
     public class AdminController : BaseController
     {

--- a/ClassTranscribeServer/Controllers/CaptionsSearchController.cs
+++ b/ClassTranscribeServer/Controllers/CaptionsSearchController.cs
@@ -3,14 +3,13 @@ using ClassTranscribeDatabase.Models;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Nest;
-using System;
 using Elasticsearch.Net;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace ClassTranscribeServer.Controllers
 {
-    [Route("api/[controller]")]
+  [Route("api/[controller]")]
     [ApiController]
     public class CaptionsSearchController : BaseController
     {

--- a/ClassTranscribeServer/Controllers/CaptionsSearchController.cs
+++ b/ClassTranscribeServer/Controllers/CaptionsSearchController.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 
 namespace ClassTranscribeServer.Controllers
 {
-  [Route("api/[controller]")]
+    [Route("api/[controller]")]
     [ApiController]
     public class CaptionsSearchController : BaseController
     {

--- a/ClassTranscribeServer/Controllers/EPubsController.cs
+++ b/ClassTranscribeServer/Controllers/EPubsController.cs
@@ -124,7 +124,7 @@ namespace ClassTranscribeServer.Controllers
         // GET: api/EPubs/ByOwner/{userid}
         [HttpGet("ByOwner/{UserId}")]
         [Authorize]
-        public async Task<ActionResult<IEnumerable<EPub>>> GetEPubs(string? userId)
+        public async Task<ActionResult<IEnumerable<EPub>>> GetEPubs(string userId = "")
         {
             try
             {
@@ -145,7 +145,7 @@ namespace ClassTranscribeServer.Controllers
             }
             catch (ArgumentException)
             {
-                return BadRequest($"Invalid request");
+                return BadRequest($"Invalid request to /api/EPubs/ByOwner/{userId}");
             }
         }
 

--- a/ClassTranscribeServer/Controllers/LogsController.cs
+++ b/ClassTranscribeServer/Controllers/LogsController.cs
@@ -16,7 +16,7 @@ using System.Threading; // CancellationToken
 
 namespace ClassTranscribeServer.Controllers
 {
-  [Route("api/[controller]")]
+    [Route("api/[controller]")]
     [ApiController]
     public class LogsController : BaseController
     {

--- a/ClassTranscribeServer/Controllers/LogsController.cs
+++ b/ClassTranscribeServer/Controllers/LogsController.cs
@@ -6,20 +6,17 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
-using Microsoft.Net.Http.Headers;
-using Newtonsoft.Json.Linq;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using System.Text;
 using System.Threading; // CancellationToken
 
 
 namespace ClassTranscribeServer.Controllers
 {
-    [Route("api/[controller]")]
+  [Route("api/[controller]")]
     [ApiController]
     public class LogsController : BaseController
     {

--- a/ClassTranscribeServer/Controllers/StaticFileController.cs
+++ b/ClassTranscribeServer/Controllers/StaticFileController.cs
@@ -1,24 +1,16 @@
 ﻿using ClassTranscribeDatabase;
-using ClassTranscribeDatabase.Models;
 using ClassTranscribeServer.Utils;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using System.Security.Claims;
-using System.Threading.Tasks;
 
 
 namespace ClassTranscribeServer.Controllers
 {
-    [Route("/data/")]
+  [Route("/data/")]
     [ApiController]
     public class StaticFileController : BaseController
     {

--- a/ClassTranscribeServer/Controllers/StaticFileController.cs
+++ b/ClassTranscribeServer/Controllers/StaticFileController.cs
@@ -10,7 +10,7 @@ using System.Security.Claims;
 
 namespace ClassTranscribeServer.Controllers
 {
-  [Route("/data/")]
+    [Route("/data/")]
     [ApiController]
     public class StaticFileController : BaseController
     {
@@ -22,43 +22,41 @@ namespace ClassTranscribeServer.Controllers
         public StaticFileController(IAuthorizationService authorizationService, 
             CTDbContext context,
             UserUtils userUtils,
+            PhysicalFileProvider provider,
             ILogger<StaticFileController> logger) : base(context, logger)
         {
             _authorizationService = authorizationService;
             _userUtils = userUtils;
-            _provider = new PhysicalFileProvider(Globals.appSettings.DATA_DIRECTORY);
+            _provider = provider;
         }
 
-        //[HttpGet("{relpath}")]
-        /* We have files in subdirectories too. Though I experimented with route matching in Startup.cs, the following route definition is required. */
-        //[Route("/data/{*id}")]
-
-        [HttpGet("{*relpath}")]   
+        // Using double asterix to preserve forward slashes: https://docs.microsoft.com/en-us/aspnet/core/fundamentals/routing?view=aspnetcore-5.0#rtr
+        // Add "required" attribute to prevent null values: https://docs.microsoft.com/en-us/aspnet/core/fundamentals/routing?view=aspnetcore-5.0#route-constraint-reference
+        [HttpGet("{**relpath:required}")]   
         // Will be Task<ActionResult> when we need to do async access checks     
-        public ActionResult GetFile(string? relpath)
+        public ActionResult GetFile(string relpath)
         {
-        
-            string urlpath =  HttpContext.Request.Path;
-           
-            string urlsubpath = urlpath.Split("/data/",2)[1]; // drop /data/
+            var fileInfo = _provider.GetFileInfo(relpath);
 
-            var fileInfo = _provider.GetFileInfo(urlsubpath);
-            if( ! fileInfo.Exists)
+            if (!fileInfo.Exists)
             {
                 return NotFound();
             }
+
             // Require Authenticated user
-            if( ! checkFileAccess(urlsubpath, User ) ) {
+            if (!checkFileAccess(relpath, User))
+            {
                 return Forbid();
             }
+
             var readStream = fileInfo.CreateReadStream();
             var mimeType = "application/octet-stream"; // arbitrary data
            
-            return File(readStream, mimeType, enableRangeProcessing:true);
+            return File(readStream, mimeType, enableRangeProcessing: true);
         }
 
         private bool checkFileAccess(string path, ClaimsPrincipal User) {
-            if(User.Identity.IsAuthenticated) {
+            if (User.Identity.IsAuthenticated && path != null) {
                 // Will be set if a valid Bearer token is presented
                 // Future implementation can verify User access for a specific resource
             //var standinMedia = await _context.Medias.FirstAsync();
@@ -68,10 +66,13 @@ namespace ClassTranscribeServer.Controllers
             //}urlsubpath.EndsWith(".txt") && 
                 return true;
             }
+
             // Referer checks are deprecated and will be removed in the future
+#nullable enable
             string? referer = HttpContext.Request.Headers["Referer"];
-               
-            if(string.IsNullOrEmpty(referer)) {
+#nullable disable
+            
+            if (string.IsNullOrEmpty(referer)) {
                 return false;
             }
             if (referer.Contains( HttpContext.Request.Host.Host,System.StringComparison.InvariantCultureIgnoreCase)) {

--- a/ClassTranscribeServer/Startup.cs
+++ b/ClassTranscribeServer/Startup.cs
@@ -3,7 +3,6 @@ using ClassTranscribeDatabase.Models;
 using ClassTranscribeServer.Authorization;
 using ClassTranscribeServer.Utils;
 using CTCommons;
-using Microsoft.AspNetCore.StaticFiles;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
@@ -29,7 +28,7 @@ using System.Text;
 
 namespace ClassTranscribeServer
 {
-    public class Startup
+  public class Startup
     {
         public Startup(IOptions<AppSettings> appSettings)
         {

--- a/ClassTranscribeServer/Startup.cs
+++ b/ClassTranscribeServer/Startup.cs
@@ -151,6 +151,7 @@ namespace ClassTranscribeServer
             services.AddScoped<Seeder>();
             services.AddScoped<UserUtils>();
             services.AddScoped<CaptionQueries>();
+            services.AddSingleton(_ => new PhysicalFileProvider(Globals.appSettings.DATA_DIRECTORY));
 
             // Configure ElasticSearch client
             if (!string.IsNullOrEmpty(Globals.appSettings.ES_CONNECTION_ADDR))
@@ -201,17 +202,17 @@ namespace ClassTranscribeServer
                  * compress images, audio and video content - which is 99.9% of our served content
                  * See https://gunnarpeipman.com/aspnet-core-compress-gzip-brotli-content-encoding/ 
                 */
-            if(false) {
-                //notused 
-                app.UseStaticFiles(new StaticFileOptions
-                {
-                    ServeUnknownFileTypes = true,
-                    FileProvider = new PhysicalFileProvider(Globals.appSettings.DATA_DIRECTORY),
-                    RequestPath = "/data",
-                    HttpsCompression = HttpsCompressionMode.DoNotCompress
-                    // OnPrepareResponse= prepareStaticFileResponse
-                });
-            }
+            //if(false) {
+            //    //notused 
+            //    app.UseStaticFiles(new StaticFileOptions
+            //    {
+            //        ServeUnknownFileTypes = true,
+            //        FileProvider = new PhysicalFileProvider(Globals.appSettings.DATA_DIRECTORY),
+            //        RequestPath = "/data",
+            //        HttpsCompression = HttpsCompressionMode.DoNotCompress
+            //        // OnPrepareResponse= prepareStaticFileResponse
+            //    });
+            //}
 
             app.UseEndpoints(endpoints =>
             {

--- a/ClassTranscribeServer/Startup.cs
+++ b/ClassTranscribeServer/Startup.cs
@@ -28,7 +28,7 @@ using System.Text;
 
 namespace ClassTranscribeServer
 {
-  public class Startup
+    public class Startup
     {
         public Startup(IOptions<AppSettings> appSettings)
         {

--- a/ClassTranscribeServer/Utils/Authorization.cs
+++ b/ClassTranscribeServer/Utils/Authorization.cs
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 
 namespace ClassTranscribeServer.Authorization
 {
-  public class ReadOfferingRequirement : IAuthorizationRequirement { }
+    public class ReadOfferingRequirement : IAuthorizationRequirement { }
     public class UpdateOfferingRequirement : IAuthorizationRequirement { }
     public class UpdateOfferingAuthorizationHandler :
     AuthorizationHandler<UpdateOfferingRequirement, Offering>

--- a/ClassTranscribeServer/Utils/Authorization.cs
+++ b/ClassTranscribeServer/Utils/Authorization.cs
@@ -6,12 +6,11 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using System;
 using System.Linq;
-using System.Security.Claims;
 using System.Threading.Tasks;
 
 namespace ClassTranscribeServer.Authorization
 {
-    public class ReadOfferingRequirement : IAuthorizationRequirement { }
+  public class ReadOfferingRequirement : IAuthorizationRequirement { }
     public class UpdateOfferingRequirement : IAuthorizationRequirement { }
     public class UpdateOfferingAuthorizationHandler :
     AuthorizationHandler<UpdateOfferingRequirement, Offering>

--- a/ClientSdk/Client.Extension.cs
+++ b/ClientSdk/Client.Extension.cs
@@ -7,7 +7,7 @@ using System.Reflection;
 
 namespace ClientSdk.Client
 {
-  public partial class MyClient
+    public partial class MyClient
     {
         partial void ProcessResponse(HttpClient request, HttpResponseMessage response)
         {

--- a/ClientSdk/Client.Extension.cs
+++ b/ClientSdk/Client.Extension.cs
@@ -1,8 +1,5 @@
 ﻿using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
-using System;
-using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 using System.Reflection;
@@ -10,7 +7,7 @@ using System.Reflection;
 
 namespace ClientSdk.Client
 {
-    public partial class MyClient
+  public partial class MyClient
     {
         partial void ProcessResponse(HttpClient request, HttpResponseMessage response)
         {

--- a/ClientSdk/ClientFactory.cs
+++ b/ClientSdk/ClientFactory.cs
@@ -1,12 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Net.Http;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Net.Http;
 
 namespace ClientSdk.Client
 {
-    public class ClientFactory
+  public class ClientFactory
     {
         public static MyClient CreateTestClient(string baseUrl, HttpClient http, string _token)
         {

--- a/ClientSdk/ClientFactory.cs
+++ b/ClientSdk/ClientFactory.cs
@@ -2,7 +2,7 @@
 
 namespace ClientSdk.Client
 {
-  public class ClientFactory
+    public class ClientFactory
     {
         public static MyClient CreateTestClient(string baseUrl, HttpClient http, string _token)
         {

--- a/DevExperiments/Program.cs
+++ b/DevExperiments/Program.cs
@@ -2,7 +2,6 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using System;
 using CTCommons.MSTranscription;
 using CTCommons;
 using Microsoft.Extensions.Options;
@@ -11,7 +10,7 @@ using CTCommons.Grpc;
 
 namespace DevExperiments
 {
-    class Program
+  class Program
     {
         static void Main(string[] args)
         {

--- a/DevExperiments/Program.cs
+++ b/DevExperiments/Program.cs
@@ -10,7 +10,7 @@ using CTCommons.Grpc;
 
 namespace DevExperiments
 {
-  class Program
+    class Program
     {
         static void Main(string[] args)
         {

--- a/DevExperiments/TempCode.cs
+++ b/DevExperiments/TempCode.cs
@@ -1,22 +1,13 @@
 ﻿using ClassTranscribeDatabase;
-using ClassTranscribeDatabase.Models;
 using Newtonsoft.Json.Linq;
 using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using CTCommons.Grpc;
-using static ClassTranscribeDatabase.CommonUtils;
 using CTCommons.MSTranscription;
-using System.Text.Json;
-using System.Text;
-using Microsoft.EntityFrameworkCore;
 
 namespace CTCommons
 {
-    class TempCode
+  class TempCode
     {
         // Deletes all Videos which don't have a file or have an invalid file (size under 1000 bytes)
 

--- a/DevExperiments/TempCode.cs
+++ b/DevExperiments/TempCode.cs
@@ -7,7 +7,7 @@ using CTCommons.MSTranscription;
 
 namespace CTCommons
 {
-  class TempCode
+    class TempCode
     {
         // Deletes all Videos which don't have a file or have an invalid file (size under 1000 bytes)
 

--- a/TaskEngine/Tasks/BuildElasticIndexTask.cs
+++ b/TaskEngine/Tasks/BuildElasticIndexTask.cs
@@ -12,8 +12,8 @@ using System.Collections.Generic;
 
 namespace TaskEngine.Tasks
 {
-  //[SuppressMessage("Microsoft.Performance", "CA1812:MarkMembersAsStatic")] // This class is never directly instantiated
-  class BuildElasticIndexTask : RabbitMQTask<string>
+    //[SuppressMessage("Microsoft.Performance", "CA1812:MarkMembersAsStatic")] // This class is never directly instantiated
+    class BuildElasticIndexTask : RabbitMQTask<string>
     {
         private readonly ElasticClient _client;
 

--- a/TaskEngine/Tasks/BuildElasticIndexTask.cs
+++ b/TaskEngine/Tasks/BuildElasticIndexTask.cs
@@ -9,10 +9,11 @@ using System.Linq;
 using Nest;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace TaskEngine.Tasks
 {
-    //[SuppressMessage("Microsoft.Performance", "CA1812:MarkMembersAsStatic")] // This class is never directly instantiated
+    [SuppressMessage("Microsoft.Performance", "CA1812:MarkMembersAsStatic")] // This class is never directly instantiated
     class BuildElasticIndexTask : RabbitMQTask<string>
     {
         private readonly ElasticClient _client;

--- a/TaskEngine/Tasks/BuildElasticIndexTask.cs
+++ b/TaskEngine/Tasks/BuildElasticIndexTask.cs
@@ -1,23 +1,19 @@
 ﻿using ClassTranscribeDatabase;
-using ClassTranscribeDatabase.Models;
 using CTCommons;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Configuration;
 using System.Threading.Tasks;
 using static ClassTranscribeDatabase.CommonUtils;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-
 using Nest;
-using Elasticsearch.Net;
 using System;
 using System.Collections.Generic;
 
 namespace TaskEngine.Tasks
 {
-    //[SuppressMessage("Microsoft.Performance", "CA1812:MarkMembersAsStatic")] // This class is never directly instantiated
-    class BuildElasticIndexTask : RabbitMQTask<string>
+  //[SuppressMessage("Microsoft.Performance", "CA1812:MarkMembersAsStatic")] // This class is never directly instantiated
+  class BuildElasticIndexTask : RabbitMQTask<string>
     {
         private readonly ElasticClient _client;
 

--- a/TaskEngine/Tasks/CleanUpElasticIndexTask.cs
+++ b/TaskEngine/Tasks/CleanUpElasticIndexTask.cs
@@ -7,9 +7,11 @@ using static ClassTranscribeDatabase.CommonUtils;
 using System.Linq;
 using Nest;
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace TaskEngine.Tasks
 {
+    [SuppressMessage("Microsoft.Performance", "CA1812:MarkMembersAsStatic")] // This class is never directly instantiated
     class CleanUpElasticIndexTask : RabbitMQTask<string>
     {
         private readonly ElasticClient _client;

--- a/TaskEngine/Tasks/CleanUpElasticIndexTask.cs
+++ b/TaskEngine/Tasks/CleanUpElasticIndexTask.cs
@@ -10,7 +10,7 @@ using System;
 
 namespace TaskEngine.Tasks
 {
-  class CleanUpElasticIndexTask : RabbitMQTask<string>
+    class CleanUpElasticIndexTask : RabbitMQTask<string>
     {
         private readonly ElasticClient _client;
         private readonly int _time_to_live;

--- a/TaskEngine/Tasks/CleanUpElasticIndexTask.cs
+++ b/TaskEngine/Tasks/CleanUpElasticIndexTask.cs
@@ -1,22 +1,16 @@
 ﻿using ClassTranscribeDatabase;
-using ClassTranscribeDatabase.Models;
 using CTCommons;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Configuration;
 using System.Threading.Tasks;
 using static ClassTranscribeDatabase.CommonUtils;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-
 using Nest;
-using Elasticsearch.Net;
 using System;
-using System.Collections.Generic;
 
 namespace TaskEngine.Tasks
 {
-    class CleanUpElasticIndexTask : RabbitMQTask<string>
+  class CleanUpElasticIndexTask : RabbitMQTask<string>
     {
         private readonly ElasticClient _client;
         private readonly int _time_to_live;

--- a/TaskEngine/Tasks/ConvertVideoToWavTask.cs
+++ b/TaskEngine/Tasks/ConvertVideoToWavTask.cs
@@ -40,7 +40,7 @@ namespace TaskEngine.Tasks
         /// <param name="videoId"></param>
         /// <param name="taskParameters"></param>
         /// <returns></returns>
-        private async Task OldOnConsumeNotUsed(string videoId, TaskParameters taskParameters) 
+        private async Task OldOnConsumeNotUsed(string videoId) 
         { 
             using (var _context = CTDbContext.CreateDbContext())
             {

--- a/TaskEngine/Tasks/CreateBoxTokenTask.cs
+++ b/TaskEngine/Tasks/CreateBoxTokenTask.cs
@@ -1,5 +1,4 @@
-﻿using ClassTranscribeDatabase;
-using CTCommons;
+﻿using CTCommons;
 using Microsoft.Extensions.Logging;
 using System.Threading.Tasks;
 using static ClassTranscribeDatabase.CommonUtils;
@@ -8,7 +7,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace TaskEngine.Tasks
 {
-    [SuppressMessage("Microsoft.Performance", "CA1812:MarkMembersAsStatic")] // This class is never directly instantiated
+  [SuppressMessage("Microsoft.Performance", "CA1812:MarkMembersAsStatic")] // This class is never directly instantiated
     class CreateBoxTokenTask : RabbitMQTask<string>
     {
         private readonly BoxAPI _box;

--- a/TaskEngine/Tasks/CreateBoxTokenTask.cs
+++ b/TaskEngine/Tasks/CreateBoxTokenTask.cs
@@ -7,7 +7,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace TaskEngine.Tasks
 {
-  [SuppressMessage("Microsoft.Performance", "CA1812:MarkMembersAsStatic")] // This class is never directly instantiated
+    [SuppressMessage("Microsoft.Performance", "CA1812:MarkMembersAsStatic")] // This class is never directly instantiated
     class CreateBoxTokenTask : RabbitMQTask<string>
     {
         private readonly BoxAPI _box;

--- a/TaskEngine/Tasks/ExampleTask.cs
+++ b/TaskEngine/Tasks/ExampleTask.cs
@@ -1,5 +1,4 @@
 ﻿using ClassTranscribeDatabase;
-using ClassTranscribeDatabase.Models;
 using CTCommons;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -10,7 +9,7 @@ using System.Linq;
 
 namespace TaskEngine.Tasks
 {
-    [SuppressMessage("Microsoft.Performance", "CA1812:MarkMembersAsStatic")] // This class is never directly instantiated
+  [SuppressMessage("Microsoft.Performance", "CA1812:MarkMembersAsStatic")] // This class is never directly instantiated
     class ExampleTask : RabbitMQTask<string>
     {
         public ExampleTask(RabbitMQConnection rabbitMQ,

--- a/TaskEngine/Tasks/ExampleTask.cs
+++ b/TaskEngine/Tasks/ExampleTask.cs
@@ -9,7 +9,7 @@ using System.Linq;
 
 namespace TaskEngine.Tasks
 {
-  [SuppressMessage("Microsoft.Performance", "CA1812:MarkMembersAsStatic")] // This class is never directly instantiated
+    [SuppressMessage("Microsoft.Performance", "CA1812:MarkMembersAsStatic")] // This class is never directly instantiated
     class ExampleTask : RabbitMQTask<string>
     {
         public ExampleTask(RabbitMQConnection rabbitMQ,

--- a/TaskEngine/Tasks/GenerateVTTFileTask.cs
+++ b/TaskEngine/Tasks/GenerateVTTFileTask.cs
@@ -33,7 +33,9 @@ namespace TaskEngine.Tasks
 
                 var vttfile = await FileRecord.GetNewFileRecordAsync(Caption.GenerateWebVTTFile(captions, transcription.Language), ".vtt");
 
+#nullable enable
                 FileRecord? existingVtt = await _context.FileRecords.FindAsync(transcription.FileId);
+#nullable disable
 
                 if (existingVtt is null)
                 {
@@ -51,7 +53,10 @@ namespace TaskEngine.Tasks
 
                 var srtfile = await FileRecord.GetNewFileRecordAsync(Caption.GenerateSrtFile(captions), ".srt");
 
+#nullable enable
                 FileRecord? existingSrt = await _context.FileRecords.FindAsync(transcription.SrtFileId);
+#nullable disable
+
                 if (existingSrt is null)
                 {
                     GetLogger().LogInformation($"{transcriptionId}: Creating new srt file {srtfile.FileName}"); 

--- a/TaskEngine/Tasks/ProcessVideoTask.cs
+++ b/TaskEngine/Tasks/ProcessVideoTask.cs
@@ -12,10 +12,10 @@ using Newtonsoft.Json.Linq;
 
 namespace TaskEngine.Tasks
 {
-  /// <summary>
-  /// This task converts a video to a common format using ffmpeg.
-  /// </summary>
-  [SuppressMessage("Microsoft.Performance", "CA1812:MarkMembersAsStatic")] // This class is never directly instantiated
+    /// <summary>
+    /// This task converts a video to a common format using ffmpeg.
+    /// </summary>
+    [SuppressMessage("Microsoft.Performance", "CA1812:MarkMembersAsStatic")] // This class is never directly instantiated
     class ProcessVideoTask : RabbitMQTask<string>
     {
         private readonly RpcClient _rpcClient;

--- a/TaskEngine/Tasks/ProcessVideoTask.cs
+++ b/TaskEngine/Tasks/ProcessVideoTask.cs
@@ -8,15 +8,14 @@ using CTCommons.Grpc;
 using static ClassTranscribeDatabase.CommonUtils;
 using CTCommons;
 using System.Diagnostics.CodeAnalysis;
-using System.Collections.Generic;
 using Newtonsoft.Json.Linq;
 
 namespace TaskEngine.Tasks
 {
-    /// <summary>
-    /// This task converts a video to a common format using ffmpeg.
-    /// </summary>
-    [SuppressMessage("Microsoft.Performance", "CA1812:MarkMembersAsStatic")] // This class is never directly instantiated
+  /// <summary>
+  /// This task converts a video to a common format using ffmpeg.
+  /// </summary>
+  [SuppressMessage("Microsoft.Performance", "CA1812:MarkMembersAsStatic")] // This class is never directly instantiated
     class ProcessVideoTask : RabbitMQTask<string>
     {
         private readonly RpcClient _rpcClient;

--- a/TaskEngine/Tasks/QueueAwakerTask.cs
+++ b/TaskEngine/Tasks/QueueAwakerTask.cs
@@ -336,12 +336,7 @@ namespace TaskEngine.Tasks
                 else if(type==TaskType.SceneDetection.ToString())
                 {
                     var id = jObject["videoMediaPlaylistId"].ToString();
-                    bool deleteExisting = false;
-                    try
-                    {
-                        deleteExisting = jObject["DeleteExisting"].Value<bool>();
-                    }
-                    catch (Exception) { }
+                    bool deleteExisting = jObject["DeleteExisting"]?.Value<bool>() ?? false;
                     GetLogger().LogInformation($"{type}:{id}");
                     var videos = await _context.Videos.Where(v=>v.Id ==id).ToListAsync();
                     if (videos.Count == 0)
@@ -386,12 +381,7 @@ namespace TaskEngine.Tasks
 
                      }
                     //TODO: These properties should not be literal strings
-                    bool deleteExisting = false;
-                    try
-                    {
-                        deleteExisting = jObject["DeleteExisting"].Value<bool>();
-                    }
-                    catch (Exception) { }
+                    bool deleteExisting = jObject["DeleteExisting"]?.Value<bool>() ?? false;
                     if (deleteExisting)
                     {
                         GetLogger().LogInformation($"{id}:Removing Transcriptions for video ({video.Id})");

--- a/TaskEngine/Tasks/RabbitMQTask.cs
+++ b/TaskEngine/Tasks/RabbitMQTask.cs
@@ -1,16 +1,14 @@
-﻿using ClassTranscribeDatabase;
-using CTCommons;
+﻿using CTCommons;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Threading.Tasks;
 using static ClassTranscribeDatabase.CommonUtils;
 using System.Diagnostics.CodeAnalysis;
 using System.Collections.Generic;
-using System.Text;
 
 namespace TaskEngine
 {
-    [SuppressMessage("Microsoft.Performance", "CA1812:MarkMembersAsStatic")] // This class is never directly instantiated
+  [SuppressMessage("Microsoft.Performance", "CA1812:MarkMembersAsStatic")] // This class is never directly instantiated
     public abstract class RabbitMQTask<T>
     {
         private RabbitMQConnection _rabbitMQ { get; set; }

--- a/TaskEngine/Tasks/RabbitMQTask.cs
+++ b/TaskEngine/Tasks/RabbitMQTask.cs
@@ -62,6 +62,10 @@ namespace TaskEngine
         protected abstract Task OnConsume(T data, TaskParameters taskParameters, ClientActiveTasks cleanup);
         protected int PostConsumeCleanup(ClientActiveTasks cleanup)
         {
+            if (cleanup == null)
+            {
+                return 0;
+            }
 
             lock (_inProgress)
             {

--- a/TaskEngine/Tasks/RabbitMQTask.cs
+++ b/TaskEngine/Tasks/RabbitMQTask.cs
@@ -8,7 +8,7 @@ using System.Collections.Generic;
 
 namespace TaskEngine
 {
-  [SuppressMessage("Microsoft.Performance", "CA1812:MarkMembersAsStatic")] // This class is never directly instantiated
+    [SuppressMessage("Microsoft.Performance", "CA1812:MarkMembersAsStatic")] // This class is never directly instantiated
     public abstract class RabbitMQTask<T>
     {
         private RabbitMQConnection _rabbitMQ { get; set; }

--- a/TaskEngine/Tasks/SceneDetectionTask.cs
+++ b/TaskEngine/Tasks/SceneDetectionTask.cs
@@ -6,7 +6,6 @@ using Microsoft.Extensions.Logging;
 using Newtonsoft.Json.Linq;
 using System.Threading.Tasks;
 using CTCommons.Grpc;
-using Grpc.Core;
 using static ClassTranscribeDatabase.CommonUtils;
 using CTCommons;
 using System.Diagnostics.CodeAnalysis;
@@ -14,7 +13,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace TaskEngine.Tasks
 {
-    [SuppressMessage("Microsoft.Performance", "CA1812:MarkMembersAsStatic")] // This class is never directly instantiated
+  [SuppressMessage("Microsoft.Performance", "CA1812:MarkMembersAsStatic")] // This class is never directly instantiated
     class SceneDetectionTask : RabbitMQTask<string>
     {
         private readonly RpcClient _rpcClient;

--- a/TaskEngine/Tasks/SceneDetectionTask.cs
+++ b/TaskEngine/Tasks/SceneDetectionTask.cs
@@ -13,7 +13,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace TaskEngine.Tasks
 {
-  [SuppressMessage("Microsoft.Performance", "CA1812:MarkMembersAsStatic")] // This class is never directly instantiated
+    [SuppressMessage("Microsoft.Performance", "CA1812:MarkMembersAsStatic")] // This class is never directly instantiated
     class SceneDetectionTask : RabbitMQTask<string>
     {
         private readonly RpcClient _rpcClient;

--- a/TaskEngine/Tasks/TranscriptionTask.cs
+++ b/TaskEngine/Tasks/TranscriptionTask.cs
@@ -4,7 +4,6 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using CTCommons.MSTranscription;
@@ -12,14 +11,13 @@ using static ClassTranscribeDatabase.CommonUtils;
 using CTCommons;
 using Newtonsoft.Json.Linq;
 using System.Diagnostics.CodeAnalysis;
-using Google.Protobuf.WellKnownTypes;
 
 namespace TaskEngine.Tasks
 {
-    /// <summary>
-    /// This task produces the transcriptions for a Video item.
-    /// </summary>
-    [SuppressMessage("Microsoft.Performance", "CA1812:MarkMembersAsStatic")] // This class is never directly instantiated
+  /// <summary>
+  /// This task produces the transcriptions for a Video item.
+  /// </summary>
+  [SuppressMessage("Microsoft.Performance", "CA1812:MarkMembersAsStatic")] // This class is never directly instantiated
     class TranscriptionTask : RabbitMQTask<string>
     {
        

--- a/TaskEngine/Tasks/TranscriptionTask.cs
+++ b/TaskEngine/Tasks/TranscriptionTask.cs
@@ -14,10 +14,10 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace TaskEngine.Tasks
 {
-  /// <summary>
-  /// This task produces the transcriptions for a Video item.
-  /// </summary>
-  [SuppressMessage("Microsoft.Performance", "CA1812:MarkMembersAsStatic")] // This class is never directly instantiated
+    /// <summary>
+    /// This task produces the transcriptions for a Video item.
+    /// </summary>
+    [SuppressMessage("Microsoft.Performance", "CA1812:MarkMembersAsStatic")] // This class is never directly instantiated
     class TranscriptionTask : RabbitMQTask<string>
     {
        

--- a/TaskEngine/TempCode.cs
+++ b/TaskEngine/TempCode.cs
@@ -3,6 +3,7 @@ using ClassTranscribeDatabase.Models;
 using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -11,6 +12,7 @@ using TaskEngine.Tasks;
 
 namespace TaskEngine
 {
+    [SuppressMessage("Microsoft.Performance", "CA1812:MarkMembersAsStatic")] // This class is never directly instantiated
     class TempCode
     {
         // Deletes all Videos which don't have a file or have an invalid file (size under 1000 bytes)

--- a/TaskEngine/TempCode.cs
+++ b/TaskEngine/TempCode.cs
@@ -11,7 +11,7 @@ using TaskEngine.Tasks;
 
 namespace TaskEngine
 {
-  class TempCode
+    class TempCode
     {
         // Deletes all Videos which don't have a file or have an invalid file (size under 1000 bytes)
 

--- a/TaskEngine/TempCode.cs
+++ b/TaskEngine/TempCode.cs
@@ -5,15 +5,13 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using CTCommons.Grpc;
 using TaskEngine.Tasks;
-using static ClassTranscribeDatabase.CommonUtils;
 
 namespace TaskEngine
 {
-    class TempCode
+  class TempCode
     {
         // Deletes all Videos which don't have a file or have an invalid file (size under 1000 bytes)
 

--- a/UnitTests/ControllerTests/CaptionsControllerTest.cs
+++ b/UnitTests/ControllerTests/CaptionsControllerTest.cs
@@ -399,7 +399,15 @@ namespace UnitTests.ControllerTests
             var expandedSpanishResults = await _controller.SearchInOffering(offering.Id, "Oui", "es");
             // will drop language filter if no results are found and research against all languages
             Assert.Single(expandedSpanishResults.Value);
+        }
 
+        [Fact]
+        public void To_PG_Language_Success()
+        {
+            Assert.Equal("english", CaptionsController.toPGLanguage("en-US"));
+            Assert.Equal("romanian", CaptionsController.toPGLanguage("ro"));
+            Assert.Equal("simple", CaptionsController.toPGLanguage("non-exist"));
+            Assert.Equal("simple", CaptionsController.toPGLanguage(null));
         }
     }
 }


### PR DESCRIPTION
Note on change in `StaticFileController.cs`, [line 51](https://github.com/classtranscribe/WebAPI/pull/257/files#diff-443fa648545ff78c1deb3374c78b9f2cbe5d2507cf407793d5448b1e4a1c383bL51): I removed the use of the variable `urlsubpath` because there is no need to explicitly drop "/data", as "/data" is already not included in the `relpath` variable because "/data" is defined as part of the route on line 21 in `StaticFileController.cs`, whereas relpath is the parameter.