### PR TITLE
Modify Route to Caption File Upload

### DIFF
--- a/ClassTranscribeServer/Controllers/CaptionsController.cs
+++ b/ClassTranscribeServer/Controllers/CaptionsController.cs
@@ -237,10 +237,10 @@ namespace ClassTranscribeServer.Controllers
             return result;
         }
 
-        // POST: api/Captions
+        // POST: api/Captions/Upload
         [DisableRequestSizeLimit]
         [Authorize(Roles = Globals.ROLE_ADMIN + "," + Globals.ROLE_TEACHING_ASSISTANT + "," + Globals.ROLE_INSTRUCTOR)]
-        [HttpPost]
+        [HttpPost("Upload")]
         [Consumes("multipart/form-data")]
         public async Task<ActionResult<IEnumerable<Caption>>> PostCaptionFile(IFormFile captionFile, [FromForm] string videoId, [FromForm] string language)
         {


### PR DESCRIPTION
The duplicate paths to POST caption made swagger unhappy.
This fix renames the Caption upload endpoint to api/Captions/Upload