### PR TITLE
Push to production

### DIFF
--- a/ClassTranscribeDatabase/Services/RabbitMQConnection.cs
+++ b/ClassTranscribeDatabase/Services/RabbitMQConnection.cs
@@ -204,11 +204,11 @@ namespace ClassTranscribeDatabase.Services
             }
         }
         /// <summary>
-        /// Deletes all Rabbit MQ queues (currently used in TaskEngine Program.cs during startup)
+        /// Purges all Rabbit MQ queues (currently used in TaskEngine Program.cs during startup)
         /// </summary>
-        public void DeleteAllQueues()
+        public void PurgeAllQueues()
         {
-            _logger.LogInformation( "DeleteAllQueues");
+            _logger.LogInformation( "DeleteAllQueue- purging messages if queues exist");
             lock (_channel)
             {
                 foreach (CommonUtils.TaskType taskType in Enum.GetValues(typeof(CommonUtils.TaskType)))
@@ -216,11 +216,13 @@ namespace ClassTranscribeDatabase.Services
                     string queueName = taskType.ToString();
                     try
                     {
-                        _channel.QueueDelete(queueName);
+                        PurgeQueue(queueName);
+                        // Nope!  _channel.QueueDelete(queueName); 
+                        // delete causes race condition with other containers
                     }
                     catch (Exception e)
                     {
-                        _logger.LogError(e, "Error deleting queue {0}", queueName);
+                        _logger.LogError(e, "Error purging queue {0}", queueName);
                     }
                 }
             }

--- a/TaskEngine/Program.cs
+++ b/TaskEngine/Program.cs
@@ -90,12 +90,10 @@ namespace TaskEngine
             // Delete any pre-existing queues on rabbitMQ.
             RabbitMQConnection rabbitMQ = serviceProvider.GetService<RabbitMQConnection>();
 
-            _logger.LogInformation("RabbitMQ - deleting all queues");
+            _logger.LogInformation("RabbitMQ - purging all queues");
 
-            rabbitMQ.DeleteAllQueues();
-            //TODO/TOREVIEW: Should we create all of the queues _before_ starting them?
-            // In the current version (all old messages deleted) it is ununnecessary
-            // But it seems cleaner to me to create them all first before starting them
+            rabbitMQ.PurgeAllQueues();
+            // Purging is cleaner than deleting when you have multiple containers connecting to the queues
 
 
 


### PR DESCRIPTION
PR #291
TaskEngine no longer deletes and recreates rabbit queues; it just performs a purge at start up. This help fixes a race condition with other containers that have references to old queues.