### PR TITLE
PurgeQueue at startup (Production Fix)

### DIFF
--- a/ClassTranscribeDatabase/Services/RabbitMQConnection.cs
+++ b/ClassTranscribeDatabase/Services/RabbitMQConnection.cs
@@ -160,6 +160,9 @@ namespace ClassTranscribeDatabase.Services
                 // See https://stackoverflow.com/questions/59493540/what-is-prefetchsize-in-rabbitmq
 
                 _channel.BasicQos(prefetchSize: 0, prefetchCount: concurrency, global: false);
+                _logger.LogInformation(" [*] Queue created. Purging old messages for {0}", queueName);
+
+                _channel.QueuePurge(queueName);
             }
 
             _logger.LogInformation(" [*] Waiting for messages, queueName - {0}", queueName);
@@ -203,42 +206,20 @@ namespace ClassTranscribeDatabase.Services
                                      consumer: consumer);
             }
         }
-        /// <summary>
-        /// Purges all Rabbit MQ queues (currently used in TaskEngine Program.cs during startup)
-        /// </summary>
-        public void PurgeAllQueues()
-        {
-            _logger.LogInformation( "DeleteAllQueue- purging messages if queues exist");
-            lock (_channel)
-            {
-                foreach (CommonUtils.TaskType taskType in Enum.GetValues(typeof(CommonUtils.TaskType)))
-                {
-                    string queueName = taskType.ToString();
-                    try
-                    {
-                        PurgeQueue(queueName);
-                        // Nope!  _channel.QueueDelete(queueName); 
-                        // delete causes race condition with other containers
-                    }
-                    catch (Exception e)
-                    {
-                        _logger.LogError(e, "Error purging queue {0}", queueName);
-                    }
-                }
-            }
-            // TODO Update JobStatus table here
-        }
 
         public void PurgeQueue(String queueName)
         {
-            _logger.LogInformation( $"PurgeQueue {queueName}");
+            _logger.LogInformation($"PurgeQueue {queueName}");
             lock (_channel)
             {
                 try
                 {
                     var count = _channel.MessageCount(queueName);
                     _logger.LogInformation("Purging queue {0}: {1} message(s) will be removed", queueName, count);
-
+                } catch(Exception) {
+                    // ignored
+                }
+                try { 
                     _channel.QueuePurge(queueName);
                 }
                 catch (Exception e)
@@ -248,9 +229,7 @@ namespace ClassTranscribeDatabase.Services
                 }
 
             }
-            // TODO Update JobStatus table here
         }
-
         #region IDisposable Support
         private bool disposedValue = false; // To detect redundant calls
 

--- a/ClassTranscribeDatabase/Services/RabbitMQConnection.cs
+++ b/ClassTranscribeDatabase/Services/RabbitMQConnection.cs
@@ -204,11 +204,11 @@ namespace ClassTranscribeDatabase.Services
             }
         }
         /// <summary>
-        /// Deletes all Rabbit MQ queues (currently used in TaskEngine Program.cs during startup)
+        /// Purges all Rabbit MQ queues (currently used in TaskEngine Program.cs during startup)
         /// </summary>
-        public void DeleteAllQueues()
+        public void PurgeAllQueues()
         {
-            _logger.LogInformation( "DeleteAllQueues");
+            _logger.LogInformation( "DeleteAllQueue- purging messages if queues exist");
             lock (_channel)
             {
                 foreach (CommonUtils.TaskType taskType in Enum.GetValues(typeof(CommonUtils.TaskType)))
@@ -216,11 +216,13 @@ namespace ClassTranscribeDatabase.Services
                     string queueName = taskType.ToString();
                     try
                     {
-                        _channel.QueueDelete(queueName);
+                        PurgeQueue(queueName);
+                        // Nope!  _channel.QueueDelete(queueName); 
+                        // delete causes race condition with other containers
                     }
                     catch (Exception e)
                     {
-                        _logger.LogError(e, "Error deleting queue {0}", queueName);
+                        _logger.LogError(e, "Error purging queue {0}", queueName);
                     }
                 }
             }

--- a/TaskEngine/Program.cs
+++ b/TaskEngine/Program.cs
@@ -90,20 +90,14 @@ namespace TaskEngine
             // Delete any pre-existing queues on rabbitMQ.
             RabbitMQConnection rabbitMQ = serviceProvider.GetService<RabbitMQConnection>();
 
-            _logger.LogInformation("RabbitMQ - purging all queues");
-
-            rabbitMQ.PurgeAllQueues();
-            // Purging is cleaner than deleting when you have multiple containers connecting to the queues
-
-
-
+            // Active queues managed by C# (concurrency > 0) are now purged after the queue is created and before messages are processed
 
             ushort concurrent_videotasks = toUInt16(Globals.appSettings.MAX_CONCURRENT_VIDEO_TASKS, NO_CONCURRENCY);
             ushort concurrent_synctasks = toUInt16(Globals.appSettings.MAX_CONCURRENT_SYNC_TASKS, MIN_CONCURRENCY);
             ushort concurrent_transcriptions = toUInt16(Globals.appSettings.MAX_CONCURRENT_TRANSCRIPTIONS, MIN_CONCURRENCY);
 
 
-            // Create and start consuming from all queues.
+            // Create and start consuming from all queues. If concurrency >=1 the queues are purged
 
 
             // Upstream Sync related

--- a/TaskEngine/Program.cs
+++ b/TaskEngine/Program.cs
@@ -90,12 +90,10 @@ namespace TaskEngine
             // Delete any pre-existing queues on rabbitMQ.
             RabbitMQConnection rabbitMQ = serviceProvider.GetService<RabbitMQConnection>();
 
-            _logger.LogInformation("RabbitMQ - deleting all queues");
+            _logger.LogInformation("RabbitMQ - purging all queues");
 
-            rabbitMQ.DeleteAllQueues();
-            //TODO/TOREVIEW: Should we create all of the queues _before_ starting them?
-            // In the current version (all old messages deleted) it is ununnecessary
-            // But it seems cleaner to me to create them all first before starting them
+            rabbitMQ.PurgeAllQueues();
+            // Purging is cleaner than deleting when you have multiple containers connecting to the queues
 
 
 

--- a/TaskEngine/Tasks/ProcessVideoTask.cs
+++ b/TaskEngine/Tasks/ProcessVideoTask.cs
@@ -30,23 +30,29 @@ namespace TaskEngine.Tasks
             Video video;
             bool videoUpdated = false;
             string subdir;
+            FileRecord video1Record = null;
+            FileRecord video2Record = null;
             using (var _context = CTDbContext.CreateDbContext())
             {
-                video = await _context.Videos
-                    //.Include(v => v.Video1)
-                    //.Include(v => v.Video2)
-                    //.Include(v => v.ProcessedVideo1)
-                    //.Include(v => v.ProcessedVideo2)
-                    .Where(v => v.Id == videoId).FirstAsync();
+                video = await _context.Videos.Where(v => v.Id == videoId).FirstAsync();
                 subdir = ToCourseOfferingSubDirectory(_context, video); // needs to traverse from Video to CO
+
+                GetLogger().LogInformation("ProcessVideo Task; Consuming video.Id=" + video.Id);
+
+                if (video.Video1Id != null)
+                {
+                    video1Record = await _context.FileRecords.FindAsync(video.Video1Id);
+                }
+                if (video.Video2Id != null)
+                {
+                    video2Record = await _context.FileRecords.FindAsync(video.Video2Id);
+                }
             }
-            GetLogger().LogInformation("Consuming" + video);
-            if(video.Duration == null && video.Video1 != null)
-            {
+            if(video.Duration == null &&  video1Record != null ) {
                 var mediaInfoResult = await _rpcClient.PythonServerClient.GetMediaInfoRPCAsync(new CTGrpc.File
                 {
-                    FilePath = video.Video1.VMPath
-                });
+                    FilePath = video1Record.VMPath
+                }); ; 
 
                 var mediaJson = JObject.Parse(mediaInfoResult.Json);
                 video.FileMediaInfo = mediaJson;
@@ -56,30 +62,30 @@ namespace TaskEngine.Tasks
             bool runbrokencode = false;
             if (runbrokencode)
             {
-                if (video.Video1 != null)
+                if (video.Video1Id != null)
                 {
                     if (video.ProcessedVideo1 == null || taskParameters.Force)
                     {
                         var file = await _rpcClient.PythonServerClient.ProcessVideoRPCAsync(new CTGrpc.File
                         {
-                            FilePath = video.Video1.VMPath
+                            FilePath = video1Record.VMPath
                         });
 
-                        //This does not work
+                        // TODO: Does this work now?
                         video.ProcessedVideo1 = await FileRecord.GetNewFileRecordAsync(file.FilePath, file.Ext, subdir);
                         videoUpdated = true;
                     }
                 }
-                if (video.Video2 != null)
+                if (video.Video2Id != null)
                 {
                     if (video.ProcessedVideo2 == null || taskParameters.Force)
                     {
                         var file = await _rpcClient.PythonServerClient.ProcessVideoRPCAsync(new CTGrpc.File
                         {
-                            FilePath = video.Video2.VMPath
+                            FilePath = video2Record.VMPath
                         });
 
-                        //This does not work
+                        // TODO: Does this work now?
                         video.ProcessedVideo2 = await FileRecord.GetNewFileRecordAsync(file.FilePath, file.Ext, subdir);
                         videoUpdated = true;
                     }

--- a/TaskEngine/Tasks/RabbitMQTask.cs
+++ b/TaskEngine/Tasks/RabbitMQTask.cs
@@ -87,7 +87,7 @@ namespace TaskEngine
         public void Consume(ushort concurrency)
         {
             if (concurrency == 0) {
-                return;
+                return; // note this means the queue will not be purged 
             }
             try
             {


### PR DESCRIPTION
RabbitMQ queues are no longer deleted when the taskengine starts. However all queues that the C# code is responsible are purged just before consume() is initiated.