### PR TITLE
Add pytube to requirements txt, add build-arg to override installed version

### DIFF
--- a/PythonRpcServer/requirements.txt
+++ b/PythonRpcServer/requirements.txt
@@ -21,7 +21,6 @@ prompt-toolkit==3.0.5
 protobuf==3.11.3
 ptyprocess==0.6.0
 Pygments==2.7.4
-#pytube3==11.0.0 not available; so use the tar.gz package
 requests==2.23.0
 requests-toolbelt==0.9.1
 scenedetect==0.5.2
@@ -37,3 +36,6 @@ prefixspan==0.5.2
 opencv-contrib-python==4.5.3.56
 mtcnn-opencv==1.0.2
 decord==0.6.0
+
+# Use latest version
+pytube     # if not available, use the tar.gz package (see Dockerfile)

--- a/pythonrpcserver.Dockerfile
+++ b/pythonrpcserver.Dockerfile
@@ -34,9 +34,10 @@ RUN python -m grpc_tools.protoc -I . --python_out=./ --grpc_python_out=./ ct.pro
 COPY ./PythonRpcServer .
 
 # Old:Downloaded tgz from https://github.com/nficano/pytube and renamed to include version
-# New: Grab link directly from https://github.com/pytube/pytube/tags
-#-L = follow redirect
-RUN curl -L https://github.com/pytube/pytube/archive/refs/tags/v12.0.0.tar.gz -o pytube.tar.gz && pip install --no-cache-dir pytube.tar.gz && rm pytube.tar.gz
+# New: Grab link directly from https://github.com/pytube/pytube/tags   (-L => follow redirect)
+# Uncomment to pull pytube tar.gz directly from github, if version unavailable on pypi (remember to comment out in PythonRpcServer/requirements.txt)
+ARG PYTUBE_VERSION=""
+RUN if [ "${PYTUBE_VERSION}" != "" ]; then curl -L https://github.com/pytube/pytube/archive/refs/tags/v${PYTUBE_VERSION}.tar.gz -o pytube.tar.gz && pip install --no-cache-dir pytube.tar.gz && rm pytube.tar.gz; fi
 
 RUN python -m nltk.downloader stopwords brown
 

--- a/pythonrpcserver.Dockerfile
+++ b/pythonrpcserver.Dockerfile
@@ -37,7 +37,7 @@ COPY ./PythonRpcServer .
 # New: Grab link directly from https://github.com/pytube/pytube/tags   (-L => follow redirect)
 # Uncomment to pull pytube tar.gz directly from github, if version unavailable on pypi (remember to comment out in PythonRpcServer/requirements.txt)
 ARG PYTUBE_VERSION=""
-RUN if [ "${PYTUBE_VERSION}" != "" ]; then curl -L https://github.com/pytube/pytube/archive/refs/tags/v${PYTUBE_VERSION}.tar.gz -o pytube.tar.gz && pip install --no-cache-dir pytube.tar.gz && rm pytube.tar.gz; fi
+RUN if [ "${PYTUBE_VERSION}" != "" ]; then curl -L https://github.com/pytube/pytube/archive/refs/tags/v${PYTUBE_VERSION}.tar.gz -o pytube.tar.gz && pip install --no-cache-dir --force-reinstall pytube.tar.gz && rm pytube.tar.gz; fi
 
 RUN python -m nltk.downloader stopwords brown
 


### PR DESCRIPTION
## Problem
`pytube` is sometimes out of date, and needs to be updated quickly after they are released to maintain compatibility with the Youtube API

## Approach
1. Add `pytube` (no pinned version) to `PythonRpcServer/requirements.txt` - this should ALWAYS attempt to download the latest pytube version from pypi
2. Add optional build-arg `PYTUBE_VERSION` - if specified, this will trigger a download of a particular version of pytube as a .tar.gz and uses pip to unzip and install it

## How to Test
1. Checkout this branch locally
2. Build image with default behavior: `docker build -t classtranscribe/pythonrpcserver -f pythonrpcserver.Dockerfile .`
     * Latest `pytube` will be installed by `requirements.txt` and will be used at runtime
     * You should see the step about PYTUBE_VERSION is followed by a no-op (nothing extra is downloaded):
```bash
#21 [17/18] RUN if [ "" != "" ]; then curl -L https://github.com/pytube/pytube/archive/refs/tags/v.tar.gz -o pytube.tar.gz && pip install --no-cache-dir --force-reinstall pytube.tar.gz && rm pytube.tar.gz; fi
#21 sha256:b35c9bfe67b74702239997f5dba25882e2ebeaddf952e11a68304a28973bb8cf
#21 DONE 0.3s
```
4. Build image and specify the optional build arg: `docker build -t classtranscribe/pythonrpcserver -f pythonrpcserver.Dockerfile . --build-arg=PYTUBE_VERSION=12.1.0`
     * Latest `pytube` will be installed by `requirements.txt`, (this is superseded at runtime by the tar.gz version that is installed during the optional step) 
     * You should see that the optional step about PYTUBE_VERSION now executes, and forces a download/reinstall of a particular version of pytube:
```bash
#22 [17/18] RUN if [ "12.1.0" != "" ]; then curl -L https://github.com/pytube/pytube/archive/refs/tags/v12.1.0.tar.gz -o pytube.tar.gz && pip install --no-cache-dir --force-reinstall pytube.tar.gz && rm pytube.tar.gz; fi
#22 sha256:afd07edd6f41d41e3c41eef5405ec53654d114625a3a540db8c06bfdc183f62a
#22 0.244   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#22 0.244                                  Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 5360k    0 5360k    0     0  4987k      0 --:--:--  0:00:01 --:--:-- 30.2M
#22 1.648 Processing ./pytube.tar.gz
#22 1.944 Building wheels for collected packages: pytube
#22 1.945   Building wheel for pytube (setup.py): started
#22 2.232   Building wheel for pytube (setup.py): finished with status 'done'
#22 2.233   Created wheel for pytube: filename=pytube-12.1.0-py3-none-any.whl size=56521 sha256=395fcff34247595406a94be3bed894fc8afa77711a2d7c97247814d7a6675c55
#22 2.233   Stored in directory: /tmp/pip-ephem-wheel-cache-c2_g9ghh/wheels/2e/f0/be/e983353906074fc6bb74d6c6394e806535b257b418a28ba753
#22 2.236 Successfully built pytube
#22 2.525 Installing collected packages: pytube
#22 2.525   Attempting uninstall: pytube
#22 2.525     Found existing installation: pytube 12.1.0
#22 2.529     Uninstalling pytube-12.1.0:
#22 2.545       Successfully uninstalled pytube-12.1.0
#22 2.602 Successfully installed pytube-12.1.0
#22 2.602 WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
#22 2.794 WARNING: You are using pip version 21.2.4; however, version 22.1.2 is available.
#22 2.794 You should consider upgrading via the '/usr/local/bin/python -m pip install --upgrade pip' command.
#22 DONE 2.9s
```