### PR TITLE
downgrade numpy

### DIFF
--- a/PythonRpcServer/requirements.txt
+++ b/PythonRpcServer/requirements.txt
@@ -11,7 +11,9 @@ ipython==7.16.3
 ipython-genutils==0.2.0
 jedi==0.17.0
 KalturaApiClient==15.20.0
-numpy==1.22.0
+numpy==1.21.6
+#Dependabot suggested 1.22 ; but that's not generally available yet
+
 #opencv-python==4.2.0.34
 # replaced by opencv-contrib-python
 parso==0.7.0


### PR DESCRIPTION
Dependabot suggested numpy 1.22 but that version if not available, so we go back to a version that is actually available
