### PR TITLE
Bump pythonrpcserver python:3.7 to 3.8

### DIFF
--- a/pythonrpcserver.Dockerfile
+++ b/pythonrpcserver.Dockerfile
@@ -1,6 +1,10 @@
 
 # Total laptop build 626 seconds
-FROM python:3.7-slim-buster
+#FROM python:3.7-slim-buster
+
+#FROM python:3.10.8-slim-buster - Failed to install scipy/numpy
+#FROM python:3.9.15-slim-buster - failed to install scipy/numpy
+FROM python:3.8.15-slim-buster
 
 RUN apt-get update
 RUN apt-get install -y curl gcc g++ make libglib2.0-0 libsm6 libxext6 libxrender-dev ffmpeg


### PR DESCRIPTION
Note, updating beyond 3.8.15 will require more work...
Attempting
FROM python:3.10.8-slim-buster
or
FROM python:3.9.15-slim-buster
Causes an error with scipy and numpy -
```sh
#0 118.2 Collecting wcwidth==0.1.9
#0 118.3   Downloading wcwidth-0.1.9-py2.py3-none-any.whl (19 kB)
#0 118.8 Collecting scikit-image==0.17.2
#0 119.2   Downloading scikit-image-0.17.2.tar.gz (29.8 MB)
#0 135.3      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 29.8/29.8 MB 4.3 MB/s eta 0:00:00
#0 140.0   Preparing metadata (setup.py): started
#0 141.0   Preparing metadata (setup.py): finished with status 'error'
#0 141.0   error: subprocess-exited-with-error
#0 141.0   
#0 141.0   × python setup.py egg_info did not run successfully.
#0 141.0   │ exit code: 1
#0 141.0   ╰─> [8 lines of output]
#0 141.0       Traceback (most recent call last):
#0 141.0         File "<string>", line 2, in <module>
#0 141.0         File "<pip-setuptools-caller>", line 34, in <module>
#0 141.0         File "/tmp/pip-install-o3qse9ej/scikit-image_cadbc7b50c6f4aa9abfe7e1b21f75afe/setup.py", line 234, in <module>
#0 141.0           'build_ext': openmp_build_ext(),
#0 141.0         File "/tmp/pip-install-o3qse9ej/scikit-image_cadbc7b50c6f4aa9abfe7e1b21f75afe/setup.py", line 58, in openmp_build_ext
#0 141.0           from numpy.distutils.command.build_ext import build_ext
#0 141.0       ModuleNotFoundError: No module named 'numpy'
#0 141.0       [end of output]
#0 141.0   
#0 141.0   note: This error originates from a subprocess, and is likely not a problem with pip.
#0 141.0 error: metadata-generation-failed
#0 141.0 
#0 141.0 × Encountered error while generating package metadata.
#0 141.0 ╰─> See above for output.
#0 141.0 
#0 141.0 note: This is an issue with the package mentioned above, not pip.
#0 141.0 hint: See above for details.
#0 141.5 
#0 141.5 [notice] A new release of pip available: 22.2.2 -> 22.3.1
#0 141.5 [notice] To update, run: pip install --upgrade pip
------
failed to solve: executor failed running [/bin/sh -c pip install --no-cache-dir -r requirements.txt]: exit code: 1
```